### PR TITLE
Remove trimming from Provider URL

### DIFF
--- a/internal/configuration/setup/Setup.go
+++ b/internal/configuration/setup/Setup.go
@@ -293,9 +293,6 @@ func parseOAuthSettings(result *models.Configuration, formObjects *[]jsonFormObj
 	if err != nil {
 		return err
 	}
-	if strings.HasSuffix(result.Authentication.OAuthProvider, "/") {
-		result.Authentication.OAuthProvider = strings.TrimRight(result.Authentication.OAuthProvider, "/")
-	}
 
 	result.Authentication.OAuthClientId, err = getFormValueString(formObjects, "oauth_id")
 	if err != nil {


### PR DESCRIPTION
Removing the trim will avoid issues with the provider URL. Accoarding to [this comment](https://github.com/coreos/go-oidc/issues/423#issuecomment-2028891100) the URL is not supposed to be trimmed. This will avoid issues with (in my case Authentik) and possibly other SSO applications aswell.

This also closes #149