### PR TITLE
Rename JSON and Redis key for AwsBucket to 'Bucket'

### DIFF
--- a/internal/models/FileList.go
+++ b/internal/models/FileList.go
@@ -16,7 +16,7 @@ type File struct {
 	PasswordHash            string         `json:"PasswordHash" redis:"PasswordHash"`             // The hash of the password (if the file is password protected)
 	HotlinkId               string         `json:"HotlinkId" redis:"HotlinkId"`                   // If file is a picture file and can be hotlinked, this is the ID for the hotlink
 	ContentType             string         `json:"ContentType" redis:"ContentType"`               // The MIME type for the file
-	AwsBucket               string         `json:"AwsBucket" redis:"AwsBucket"`                   // If the file is stored in the cloud, this is the bucket that is being used
+	AwsBucket               string         `json:"Bucket" redis:"Bucket"`                         // If the file is stored in the cloud, this is the bucket that is being used
 	ExpireAtString          string         `json:"ExpireAtString" redis:"ExpireAtString"`         // Time expiry in a human-readable format in local time
 	ExpireAt                int64          `json:"ExpireAt" redis:"ExpireAt"`                     // "UTC timestamp of file expiry
 	SizeBytes               int64          `json:"SizeBytes" redis:"SizeBytes"`                   // Filesize in bytes


### PR DESCRIPTION
# Rename JSON and Redis Key from 'AwsBucket' to 'Bucket'

## Summary
This change aligns field naming in the codebase with the expected parameter name in `cloudconfig.yml`. The AWS configuration expects the bucket parameter to be named `Bucket`, not `AwsBucket`.

## Issue Details
The current implementation attempts to read the AWS bucket name from a field called `AwsBucket`, but `cloudconfig.yml` stores this value under the key `Bucket`. This mismatch results in the uploader receiving an empty bucket name, which causes errors during operation.

## Fix
Updating all JSON and Redis references to use the key name `Bucket` instead of `AwsBucket` ensures consistent naming across the application and resolves the upload errors.

## Correction
In my previous PR, I incorrectly stated that the value in `cloudconfig.yml` was unset. The actual issue is the naming inconsistency between the configuration file and the code that reads from it.