### PR TITLE
DuplicateFile setting hotlink on wrong file object

### DIFF
--- a/internal/storage/FileServing.go
+++ b/internal/storage/FileServing.go
@@ -425,7 +425,7 @@ func DuplicateFile(file models.File, parametersToChange int, newFileName string,
 
 	newFile.Id = createNewId()
 	newFile.DownloadCount = 0
-	AddHotlink(&file)
+	AddHotlink(&newFile)
 
 	database.SaveMetaData(newFile)
 	return newFile, nil


### PR DESCRIPTION
There's a bug in the DuplicateFile function where it calls AddHotlink(&file) instead of AddHotlink(&newFile). The hotlink is being added to the original file rather than the duplicate.