### PR TITLE
Added UploadTime in the Models to allow sort by update time.

### DIFF
--- a/internal/models/FileList.go
+++ b/internal/models/FileList.go
@@ -3,8 +3,9 @@ package models
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/jinzhu/copier"
 	"net/url"
+
+	"github.com/jinzhu/copier"
 )
 
 // File is a struct used for saving information about an uploaded file
@@ -17,6 +18,7 @@ type File struct {
 	HotlinkId               string         `json:"HotlinkId" redis:"HotlinkId"`                   // If file is a picture file and can be hotlinked, this is the ID for the hotlink
 	ContentType             string         `json:"ContentType" redis:"ContentType"`               // The MIME type for the file
 	AwsBucket               string         `json:"AwsBucket" redis:"AwsBucket"`                   // If the file is stored in the cloud, this is the bucket that is being used
+	UploadTime              int64          `json:"UploadTime" redis:"UploadTime"`                 // UTC timestamp of the time the file was uploaded
 	ExpireAtString          string         `json:"ExpireAtString" redis:"ExpireAtString"`         // Time expiry in a human-readable format in local time
 	ExpireAt                int64          `json:"ExpireAt" redis:"ExpireAt"`                     // "UTC timestamp of file expiry
 	SizeBytes               int64          `json:"SizeBytes" redis:"SizeBytes"`                   // Filesize in bytes
@@ -31,26 +33,27 @@ type File struct {
 
 // FileApiOutput will be displayed for public outputs from the ID, hiding sensitive information
 type FileApiOutput struct {
-	Id                           string `json:"Id"`                           // The internal ID of the file
-	Name                         string `json:"Name"`                         // The filename. Will be 'Encrypted file' for end-to-end encrypted files
-	Size                         string `json:"Size"`                         // Filesize in a human-readable format
-	HotlinkId                    string `json:"HotlinkId"`                    // If file is a picture file and can be hotlinked, this is the ID for the hotlink
-	ContentType                  string `json:"ContentType"`                  // The MIME type for the file
-	ExpireAtString               string `json:"ExpireAtString"`               // Time expiry in a human-readable format in local time
-	UrlDownload                  string `json:"UrlDownload"`                  // The public download URL for the file
-	UrlHotlink                   string `json:"UrlHotlink"`                   // The public hotlink URL for the file
-	ExpireAt                     int64  `json:"ExpireAt"`                     // "UTC timestamp of file expiry
-	SizeBytes                    int64  `json:"SizeBytes"`                    // Filesize in bytes
-	DownloadsRemaining           int    `json:"DownloadsRemaining"`           // The remaining downloads for this file
-	DownloadCount                int    `json:"DownloadCount"`                // The amount of times the file has been downloaded
-	UnlimitedDownloads           bool   `json:"UnlimitedDownloads"`           // True if the uploader did not limit the downloads
-	UnlimitedTime                bool   `json:"UnlimitedTime"`                // True if the uploader did not limit the time
-	RequiresClientSideDecryption bool   `json:"RequiresClientSideDecryption"` // True if the file has to be decrypted client-side
-	IsEncrypted                  bool   `json:"IsEncrypted"`                  // True if the file is encrypted
-	IsEndToEndEncrypted          bool   `json:"IsEndToEndEncrypted"`          // True if the file is end-to-end encrypted
-	IsPasswordProtected          bool   `json:"IsPasswordProtected"`          // True if a password has to be entered before downloading the file
-	IsSavedOnLocalStorage        bool   `json:"IsSavedOnLocalStorage"`        // True if the file does not use cloud storage
-	UploaderId                   int    `json:"UploaderId"`                   // The user ID of the uploader
+	Id                           string `json:"Id"`                            // The internal ID of the file
+	Name                         string `json:"Name"`                          // The filename. Will be 'Encrypted file' for end-to-end encrypted files
+	Size                         string `json:"Size"`                          // Filesize in a human-readable format
+	HotlinkId                    string `json:"HotlinkId"`                     // If file is a picture file and can be hotlinked, this is the ID for the hotlink
+	ContentType                  string `json:"ContentType"`                   // The MIME type for the file
+	ExpireAtString               string `json:"ExpireAtString"`                // Time expiry in a human-readable format in local time
+	UrlDownload                  string `json:"UrlDownload"`                   // The public download URL for the file
+	UrlHotlink                   string `json:"UrlHotlink"`                    // The public hotlink URL for the file
+	UploadTime                   int64  `json:"UploadTime" redis:"UploadTime"` // UTC timestamp of the time the file was uploaded
+	ExpireAt                     int64  `json:"ExpireAt"`                      // "UTC timestamp of file expiry
+	SizeBytes                    int64  `json:"SizeBytes"`                     // Filesize in bytes
+	DownloadsRemaining           int    `json:"DownloadsRemaining"`            // The remaining downloads for this file
+	DownloadCount                int    `json:"DownloadCount"`                 // The amount of times the file has been downloaded
+	UnlimitedDownloads           bool   `json:"UnlimitedDownloads"`            // True if the uploader did not limit the downloads
+	UnlimitedTime                bool   `json:"UnlimitedTime"`                 // True if the uploader did not limit the time
+	RequiresClientSideDecryption bool   `json:"RequiresClientSideDecryption"`  // True if the file has to be decrypted client-side
+	IsEncrypted                  bool   `json:"IsEncrypted"`                   // True if the file is encrypted
+	IsEndToEndEncrypted          bool   `json:"IsEndToEndEncrypted"`           // True if the file is end-to-end encrypted
+	IsPasswordProtected          bool   `json:"IsPasswordProtected"`           // True if a password has to be entered before downloading the file
+	IsSavedOnLocalStorage        bool   `json:"IsSavedOnLocalStorage"`         // True if the file does not use cloud storage
+	UploaderId                   int    `json:"UploaderId"`                    // The user ID of the uploader
 }
 
 // EncryptionInfo holds information about the encryption used on the file

--- a/internal/models/FileList_test.go
+++ b/internal/models/FileList_test.go
@@ -2,8 +2,9 @@ package models
 
 import (
 	"errors"
-	"github.com/forceu/gokapi/internal/test"
 	"testing"
+
+	"github.com/forceu/gokapi/internal/test"
 )
 
 func TestToJsonResult(t *testing.T) {
@@ -13,6 +14,7 @@ func TestToJsonResult(t *testing.T) {
 		Size:               "10 B",
 		SizeBytes:          10,
 		SHA1:               "sha256",
+		UploadTime:         25,
 		ExpireAt:           50,
 		ExpireAtString:     "future",
 		DownloadsRemaining: 1,
@@ -30,8 +32,8 @@ func TestToJsonResult(t *testing.T) {
 		UnlimitedDownloads: true,
 		UnlimitedTime:      true,
 	}
-	test.IsEqualString(t, file.ToJsonResult("serverurl/", false), `{"Result":"OK","FileInfo":{"Id":"testId","Name":"testName","Size":"10 B","HotlinkId":"hotlinkid","ContentType":"text/html","ExpireAtString":"future","UrlDownload":"serverurl/d?id=testId","UrlHotlink":"","ExpireAt":50,"SizeBytes":10,"DownloadsRemaining":1,"DownloadCount":3,"UnlimitedDownloads":true,"UnlimitedTime":true,"RequiresClientSideDecryption":true,"IsEncrypted":true,"IsEndToEndEncrypted":false,"IsPasswordProtected":true,"IsSavedOnLocalStorage":false,"UploaderId":2},"IncludeFilename":false}`)
-	test.IsEqualString(t, file.ToJsonResult("serverurl/", true), `{"Result":"OK","FileInfo":{"Id":"testId","Name":"testName","Size":"10 B","HotlinkId":"hotlinkid","ContentType":"text/html","ExpireAtString":"future","UrlDownload":"serverurl/d/testId/testName","UrlHotlink":"","ExpireAt":50,"SizeBytes":10,"DownloadsRemaining":1,"DownloadCount":3,"UnlimitedDownloads":true,"UnlimitedTime":true,"RequiresClientSideDecryption":true,"IsEncrypted":true,"IsEndToEndEncrypted":false,"IsPasswordProtected":true,"IsSavedOnLocalStorage":false,"UploaderId":2},"IncludeFilename":true}`)
+	test.IsEqualString(t, file.ToJsonResult("serverurl/", false), `{"Result":"OK","FileInfo":{"Id":"testId","Name":"testName","Size":"10 B","HotlinkId":"hotlinkid","ContentType":"text/html","ExpireAtString":"future","UrlDownload":"serverurl/d?id=testId","UrlHotlink":"","UploadTime":25,"ExpireAt":50,"SizeBytes":10,"DownloadsRemaining":1,"DownloadCount":3,"UnlimitedDownloads":true,"UnlimitedTime":true,"RequiresClientSideDecryption":true,"IsEncrypted":true,"IsEndToEndEncrypted":false,"IsPasswordProtected":true,"IsSavedOnLocalStorage":false,"UploaderId":2},"IncludeFilename":false}`)
+	test.IsEqualString(t, file.ToJsonResult("serverurl/", true), `{"Result":"OK","FileInfo":{"Id":"testId","Name":"testName","Size":"10 B","HotlinkId":"hotlinkid","ContentType":"text/html","ExpireAtString":"future","UrlDownload":"serverurl/d/testId/testName","UrlHotlink":"","UploadTime":25,"ExpireAt":50,"SizeBytes":10,"DownloadsRemaining":1,"DownloadCount":3,"UnlimitedDownloads":true,"UnlimitedTime":true,"RequiresClientSideDecryption":true,"IsEncrypted":true,"IsEndToEndEncrypted":false,"IsPasswordProtected":true,"IsSavedOnLocalStorage":false,"UploaderId":2},"IncludeFilename":true}`)
 }
 
 func TestIsLocalStorage(t *testing.T) {

--- a/internal/models/FileUpload.go
+++ b/internal/models/FileUpload.go
@@ -11,6 +11,7 @@ type UploadRequest struct {
 	UnlimitedDownload   bool
 	UnlimitedTime       bool
 	IsEndToEndEncrypted bool
+	UploadTime          int64
 	ExpiryTimestamp     int64
 	RealSize            int64
 }

--- a/internal/storage/FileServing.go
+++ b/internal/storage/FileServing.go
@@ -10,6 +10,16 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
+	"log"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/forceu/gokapi/internal/configuration"
 	"github.com/forceu/gokapi/internal/configuration/database"
 	"github.com/forceu/gokapi/internal/encryption"
@@ -25,15 +35,6 @@ import (
 	"github.com/forceu/gokapi/internal/webserver/headers"
 	"github.com/forceu/gokapi/internal/webserver/sse"
 	"github.com/jinzhu/copier"
-	"io"
-	"log"
-	"mime/multipart"
-	"net/http"
-	"os"
-	"path/filepath"
-	"strconv"
-	"strings"
-	"time"
 )
 
 // ErrorFileTooLarge is an error that is called when a file larger than the set maximum is uploaded
@@ -299,6 +300,7 @@ func createNewMetaData(hash string, fileHeader chunking.FileHeader, userId int, 
 		Size:               helper.ByteCountSI(fileHeader.Size),
 		SizeBytes:          fileHeader.Size,
 		ContentType:        fileHeader.ContentType,
+		UploadTime:         uploadRequest.UploadTime,
 		ExpireAt:           uploadRequest.ExpiryTimestamp,
 		ExpireAtString:     FormatTimestamp(uploadRequest.ExpiryTimestamp),
 		DownloadsRemaining: uploadRequest.AllowedDownloads,

--- a/internal/webserver/api/Api.go
+++ b/internal/webserver/api/Api.go
@@ -3,6 +3,11 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
 	"github.com/forceu/gokapi/internal/configuration"
 	"github.com/forceu/gokapi/internal/configuration/database"
 	"github.com/forceu/gokapi/internal/helper"
@@ -10,10 +15,6 @@ import (
 	"github.com/forceu/gokapi/internal/models"
 	"github.com/forceu/gokapi/internal/storage"
 	"github.com/forceu/gokapi/internal/webserver/fileupload"
-	"io"
-	"net/http"
-	"strings"
-	"time"
 )
 
 const lengthPublicId = 35

--- a/internal/webserver/fileupload/FileUpload.go
+++ b/internal/webserver/fileupload/FileUpload.go
@@ -1,16 +1,17 @@
 package fileupload
 
 import (
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
 	"github.com/forceu/gokapi/internal/configuration"
 	"github.com/forceu/gokapi/internal/configuration/database"
 	"github.com/forceu/gokapi/internal/logging"
 	"github.com/forceu/gokapi/internal/models"
 	"github.com/forceu/gokapi/internal/storage"
 	"github.com/forceu/gokapi/internal/storage/chunking"
-	"io"
-	"net/http"
-	"strconv"
-	"time"
 )
 
 // ProcessCompleteFile processes a file upload request
@@ -99,6 +100,7 @@ func CreateUploadConfig(allowedDownloads, expiryDays int, password string, unlim
 	return models.UploadRequest{
 		AllowedDownloads:    allowedDownloads,
 		Expiry:              expiryDays,
+		UploadTime:          time.Now().Unix(),
 		ExpiryTimestamp:     time.Now().Add(time.Duration(expiryDays) * time.Hour * 24).Unix(),
 		Password:            password,
 		ExternalUrl:         settings.ServerUrl,


### PR DESCRIPTION
#237 
- Added `UploadTime` as `int64` in `FileList.go`  `File` and `FileApiOutput` structs and also modified the `FileList_Test.go` to accomodate that.
- Modified the `createNewMetaData` method in `FileServing.go` to accept an `uploadTime` parameter and modified file that uses this method, made them aps the current time stamp when calling it as `time.Now().Unix()`. 
- Added the `UploadTime` as `int64` in `UploadRequest` to send the `time.Now().Unix()` to `apiUploadFile` and others.