### PR TITLE
add shorter hotlink route handler

### DIFF
--- a/internal/models/FileList.go
+++ b/internal/models/FileList.go
@@ -99,7 +99,7 @@ func getHotlinkUrl(input FileApiOutput, serverUrl string, useFilename bool) stri
 		return ""
 	}
 	if input.HotlinkId != "" {
-		return serverUrl + "hotlink/" + input.HotlinkId
+		return serverUrl + "h/" + input.HotlinkId
 	}
 	if useFilename {
 		return serverUrl + "dh/" + input.Id + "/" + url.PathEscape(input.Name)

--- a/internal/models/FileList_test.go
+++ b/internal/models/FileList_test.go
@@ -75,7 +75,7 @@ func TestGetHolinkUrl(t *testing.T) {
 	test.IsEqualString(t, url, "")
 	file.RequiresClientSideDecryption = false
 	url = getHotlinkUrl(file, "testserver/", false)
-	test.IsEqualString(t, url, "testserver/hotlink/test")
+	test.IsEqualString(t, url, "testserver/h/test")
 	file.HotlinkId = ""
 	url = getHotlinkUrl(file, "testserver/", false)
 	test.IsEqualString(t, url, "testserver/downloadFile?id=testfile")

--- a/internal/test/testconfiguration/TestConfiguration.go
+++ b/internal/test/testconfiguration/TestConfiguration.go
@@ -58,6 +58,7 @@ func Create(initFiles bool) {
 	writeTestSessions()
 	writeTestFiles()
 	database.SaveHotlink(models.File{Id: "n1tSTAGj8zan9KaT4u6p", HotlinkId: "PhSs6mFtf8O5YGlLMfNw9rYXx9XRNkzCnJZpQBi7inunv3Z4A.jpg", ExpireAt: time.Now().Add(time.Hour).Unix()})
+	database.SaveHotlink(models.File{Id: "t4efyghvrill1w1zary2", HotlinkId: "wjqlzpq2.jpg", ExpireAt: time.Now().Add(time.Hour).Unix()})
 	writeApiKeys()
 	writeTestUploadStatus()
 	database.Close()
@@ -65,6 +66,7 @@ func Create(initFiles bool) {
 	if initFiles {
 		os.MkdirAll(dataDir, 0777)
 		os.WriteFile(dataDir+"/a8fdc205a9f19cc1c7507a60c4f01b13d11d7fd0", []byte("123"), 0777)
+		os.WriteFile(dataDir+"/a8fdc205a9f19cc1c7507a60c4f01b13d11d7fd1", []byte("123"), 0777)
 		os.WriteFile(dataDir+"/c4f9375f9834b4e7f0a528cc65c055702bf5f24a", []byte("456"), 0777)
 		os.WriteFile(dataDir+"/e017693e4a04a59d0b0f400fe98177fe7ee13cf7", []byte("789"), 0777)
 		os.WriteFile(dataDir+"/2341354656543213246465465465432456898794", []byte("abc"), 0777)
@@ -368,6 +370,18 @@ func writeTestFiles() {
 		DownloadsRemaining: 1,
 		ContentType:        "text/html",
 		HotlinkId:          "PhSs6mFtf8O5YGlLMfNw9rYXx9XRNkzCnJZpQBi7inunv3Z4A.jpg",
+		UserId:             5,
+	})
+	database.SaveMetaData(models.File{
+		Id:                 "t4efyghvrill1w1zary2",
+		Name:               "picture.jpg",
+		Size:               "4 B",
+		SHA1:               "a8fdc205a9f19cc1c7507a60c4f01b13d11d7fd1",
+		ExpireAt:           2147483646,
+		ExpireAtString:     "2021-05-04 15:19",
+		DownloadsRemaining: 1,
+		ContentType:        "text/html",
+		HotlinkId:          "wjqlzpq2.jpg",
 		UserId:             5,
 	})
 	database.SaveMetaData(models.File{

--- a/internal/webserver/Webserver.go
+++ b/internal/webserver/Webserver.go
@@ -102,7 +102,8 @@ func Start() {
 	mux.HandleFunc("/error-header", showErrorHeader)
 	mux.HandleFunc("/error-oauth", showErrorIntOAuth)
 	mux.HandleFunc("/forgotpw", forgotPassword)
-	mux.HandleFunc("/hotlink/", showHotlink)
+	mux.HandleFunc("/h/", showHotlink)
+	mux.HandleFunc("/hotlink/", showHotlink) // backward compatibility
 	mux.HandleFunc("/index", showIndex)
 	mux.HandleFunc("/login", showLogin)
 	mux.HandleFunc("/logs", requireLogin(showLogs, true, false))
@@ -510,10 +511,11 @@ func showDownload(w http.ResponseWriter, r *http.Request) {
 	helper.CheckIgnoreTimeout(err)
 }
 
-// Handling of /hotlink/
+// Handling of /h/ and /hotlink/
 // Hotlinks an image or returns a static error image if image has expired
 func showHotlink(w http.ResponseWriter, r *http.Request) {
 	hotlinkId := strings.Replace(r.URL.Path, "/hotlink/", "", 1)
+	hotlinkId = strings.Replace(hotlinkId, "/h/", "", 1)
 	addNoCacheHeader(w)
 	file, ok := storage.GetFileByHotlink(hotlinkId)
 	if !ok {

--- a/internal/webserver/Webserver_test.go
+++ b/internal/webserver/Webserver_test.go
@@ -331,9 +331,17 @@ func TestDownloadHotlink(t *testing.T) {
 		Url:             "http://127.0.0.1:53843/hotlink/PhSs6mFtf8O5YGlLMfNw9rYXx9XRNkzCnJZpQBi7inunv3Z4A.jpg",
 		RequiredContent: []string{"123"},
 	})
+	test.HttpPageResult(t, test.HttpTestConfig{
+		Url:             "http://127.0.0.1:53843/h/wjqlzpq2.jpg",
+		RequiredContent: []string{"123"},
+	})
 	// Download expired hotlink
 	test.HttpPageResult(t, test.HttpTestConfig{
 		Url:             "http://127.0.0.1:53843/hotlink/PhSs6mFtf8O5YGlLMfNw9rYXx9XRNkzCnJZpQBi7inunv3Z4A.jpg",
+		RequiredContent: []string{"The requested file has expired"},
+	})
+	test.HttpPageResult(t, test.HttpTestConfig{
+		Url:             "http://127.0.0.1:53843/h/wjqlzpq2.jpg",
 		RequiredContent: []string{"The requested file has expired"},
 	})
 }

--- a/internal/webserver/api/Api_test.go
+++ b/internal/webserver/api/Api_test.go
@@ -1189,7 +1189,7 @@ func TestList(t *testing.T) {
 	test.IsEqualInt(t, w.Code, 200)
 	err := json.Unmarshal(w.Body.Bytes(), &result)
 	test.IsNil(t, err)
-	test.IsEqualInt(t, len(result), 11)
+	test.IsEqualInt(t, len(result), 12)
 
 	removeUserPermission(t, idUser, models.UserPermListOtherUploads)
 	w, r = getRecorder(apiUrl, apiKey.Id, []test.Header{})

--- a/internal/webserver/web/static/apidocumentation/openapi.json
+++ b/internal/webserver/web/static/apidocumentation/openapi.json
@@ -1045,7 +1045,7 @@
           "UrlHotlink": {
             "type": "string",
             "description": "The public hotlink URL for the file",
-            "example": "https://gokapi.server/hotlink/tDMs0U8MvRFwK69PfjagI7F87C13UVeQuOGDvtCG.jpg"
+            "example": "https://gokapi.server/h/tDMs0U8MvRFwK69PfjagI7F87C13UVeQuOGDvtCG.jpg"
           },
           "ExpireAt": {
             "type": "integer",

--- a/openapi.json
+++ b/openapi.json
@@ -1045,7 +1045,7 @@
           "UrlHotlink": {
             "type": "string",
             "description": "The public hotlink URL for the file",
-            "example": "https://gokapi.server/hotlink/tDMs0U8MvRFwK69PfjagI7F87C13UVeQuOGDvtCG.jpg"
+            "example": "https://gokapi.server/h/tDMs0U8MvRFwK69PfjagI7F87C13UVeQuOGDvtCG.jpg"
           },
           "ExpireAt": {
             "type": "integer",


### PR DESCRIPTION
Replaced default hotlink route handler from `/hotlink/` to `/h/` keeping `/hotlink/` still alive for already posted links.