### PR TITLE
Docker support for UMASK, PUID, PGID environment variables #285

### DIFF
--- a/dockerentry.sh
+++ b/dockerentry.sh
@@ -1,6 +1,13 @@
 #!/bin/sh
-if [ "$DOCKER_NONROOT" = "true" ]; then
+if [ -n "$UMASK" ]; then
+	umask "$UMASK"
+fi && \
+if [ -n "$PUID$PGID" ] || [ "$DOCKER_NONROOT" = "true" ]; then
 	echo "Setting permissions" && \
+	PUID="${PUID-$(id -u gokapi)}" && \
+	PGID="${PGID-$(id -g gokapi)}" && \
+	sed -E 's/^(gokapi:x):([0-9]+)(.*)$/\1:'"$PGID"'\3/g' -i /etc/group && \
+	sed -E 's/^(gokapi:x):([0-9]+:[0-9]+)(.*)$/\1:'"$PUID:$PGID"'\3/' -i /etc/passwd && \
 	chown -R gokapi:gokapi /app && \
 	chmod -R 700 /app && \
 	echo "Starting application" && \


### PR DESCRIPTION
This updates `dockerentry.sh` to support user assignable UMASK, PUID, and PGID variables as requested in https://github.com/Forceu/Gokapi/issues/285

Since `usermod` and `groupmod` were not available sed is used to update `/etc/passwd` and `/etc/groups`.

Both `PUID` and `PGID` imply `DOCKER_NONROOT`.