### PR TITLE
fix: Files with pending deletion can still be downloaded until deletion is complete

### DIFF
--- a/internal/storage/FileServing.go
+++ b/internal/storage/FileServing.go
@@ -565,6 +565,9 @@ func GetFile(id string) (models.File, bool) {
 	if !ok {
 		return emptyResult, false
 	}
+	if file.IsPendingForDeletion() {
+		return emptyResult, false
+	}
 	if IsExpiredFile(file, time.Now().Unix()) {
 		return emptyResult, false
 	}

--- a/internal/storage/FileServing_test.go
+++ b/internal/storage/FileServing_test.go
@@ -69,6 +69,25 @@ func TestGetFile(t *testing.T) {
 	_, result = GetFile(file.Id)
 	test.IsEqualBool(t, result, false)
 
+	// Test pending deletion - file should not be retrievable when pending deletion
+	pendingFile := models.File{
+		Id:                 "testpendingdelete",
+		Name:               "testpendingdelete",
+		SHA1:               "e017693e4a04a59d0b0f400fe98177fe7ee13cf7",
+		UnlimitedDownloads: true,
+		UnlimitedTime:      true,
+		PendingDeletion:    time.Now().Add(time.Hour).Unix(),
+	}
+	database.SaveMetaData(pendingFile)
+	_, result = GetFile(pendingFile.Id)
+	test.IsEqualBool(t, result, false)
+	// Clean up - cancel pending deletion to allow normal retrieval
+	pendingFile.PendingDeletion = 0
+	database.SaveMetaData(pendingFile)
+	_, result = GetFile(pendingFile.Id)
+	test.IsEqualBool(t, result, true)
+	// Clean up test data
+	database.DeleteMetaData(pendingFile.Id)
 }
 
 func TestGetEncInfoFromExistingFile(t *testing.T) {


### PR DESCRIPTION
Fixes #341

## Changes
- Add check in `GetFile()` to return false for files with pending deletion status
- Add test case to verify files with pending deletion cannot be retrieved

🤖 Generated with [Claude Code](https://claude.com/claude-code)