### PR TITLE
fix: Bug: Share button is not displayed properly

### DIFF
--- a/internal/webserver/web/static/js/admin_ui_upload.js
+++ b/internal/webserver/web/static/js/admin_ui_upload.js
@@ -732,6 +732,7 @@ function createButtonGroup(item) {
     groupContainer.className = "btn-toolbar";
     groupContainer.setAttribute("role", "toolbar");
 
+    // Button group for Copy URL
     const group1 = document.createElement("div");
     group1.className = "btn-group me-2";
     group1.setAttribute("role", "group");
@@ -784,6 +785,11 @@ function createButtonGroup(item) {
     dropdown1.appendChild(liDr1);
     group1.appendChild(dropdown1);
 
+    // Button group for Share
+    const groupShare = document.createElement("div");
+    groupShare.className = "btn-group me-2";
+    groupShare.setAttribute("role", "group");
+
     // Share button
     const btnShare = document.createElement("button");
     btnShare.type = "button";
@@ -791,16 +797,15 @@ function createButtonGroup(item) {
     btnShare.title = "Share";
     btnShare.onclick = () => shareUrl(item.Id);
     btnShare.innerHTML = `<i class="bi bi-share"></i>`;
-    group1.appendChild(btnShare);
+    groupShare.appendChild(btnShare);
 
-
-    // Dropdown toggle 
+    // Dropdown toggle for Share
     const btnDropdown2 = document.createElement("button");
     btnDropdown2.type = "button";
     btnDropdown2.className = "btn btn-outline-light btn-sm dropdown-toggle dropdown-toggle-split";
     btnDropdown2.setAttribute("data-bs-toggle", "dropdown");
     btnDropdown2.setAttribute("aria-expanded", "false");
-    group1.appendChild(btnDropdown2);
+    groupShare.appendChild(btnDropdown2);
 
     const dropdown2 = document.createElement("ul");
     dropdown2.className = "dropdown-menu dropdown-menu-end";
@@ -827,7 +832,7 @@ function createButtonGroup(item) {
     emailA.innerHTML = `<i class="bi bi-envelope"></i> Email`;
     emailLi.appendChild(emailA);
     dropdown2.appendChild(emailLi);
-    group1.appendChild(dropdown2);
+    groupShare.appendChild(dropdown2);
 
     // Button group for Edit/Delete
     const group2 = document.createElement("div");
@@ -877,6 +882,7 @@ function createButtonGroup(item) {
     group2.appendChild(btnDelete);
 
     groupContainer.appendChild(group1);
+    groupContainer.appendChild(groupShare);
     groupContainer.appendChild(group2);
 
     return groupContainer;

--- a/internal/webserver/web/templates/html_admin.tmpl
+++ b/internal/webserver/web/templates/html_admin.tmpl
@@ -84,6 +84,8 @@
 						<div class="btn-toolbar" role="toolbar" >
 						  <div class="btn-group me-2" role="group">
 						     {{ template "admin_button_copyurl" (newAdminButtonContext . $.ActiveUser)}}
+						  </div>
+						  <div class="btn-group me-2" role="group">
 						     {{ template "admin_button_share" (newAdminButtonContext . $.ActiveUser)}}
 						  </div>
 						  <div class="btn-group me-2" role="group">
@@ -246,9 +248,9 @@
 		    <button type="button" class="btn btn-outline-light btn-sm dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
 		    </button>
 			<ul class="dropdown-menu dropdown-menu-end" data-bs-theme="dark" >
-			    <li style="cursor: pointer;"><a class="dropdown-item" id="qrcode-{{ .CurrentFile.Id }}" title="Open QR Code" class="btn btn-outline-light btn-sm" onclick="showQrCode('{{ .CurrentFile.UrlDownload }}');"><i class="bi bi-qr-code"></i> QR Code</a></li>
+			    <li style="cursor: pointer;"><a class="dropdown-item" id="qrcode-{{ .CurrentFile.Id }}" title="Open QR Code" onclick="showQrCode('{{ .CurrentFile.UrlDownload }}');"><i class="bi bi-qr-code"></i> QR Code</a></li>
 			    <li style="cursor: pointer;"><a class="dropdown-item" id="email-{{ .CurrentFile.Id }}" href="mailto:?body={{ .CurrentFile.UrlDownload | urlquery}}"
-			       target="_blank" title="Share via email" class="btn btn-outline-light btn-sm"><i class="bi bi-envelope"></i> Email</a></li>
+			       target="_blank" title="Share via email"><i class="bi bi-envelope"></i> Email</a></li>
 			</ul>
 {{ end }}
 


### PR DESCRIPTION
Fixes #274

## Changes
- Separated share button split-dropdown into its own `btn-group` in template and JavaScript
- Removed conflicting CSS classes (`btn btn-outline-light btn-sm`) from dropdown items that already have `dropdown-item` class