### PR TITLE
Fix setup URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ docker run -d \
   f0rc3/gokapi:latest
 ```
 
-Then visit ``http://localhost:53842`` and follow the setup wizard.
+Then visit ``http://localhost:53842/setup`` and follow the setup wizard.
 
 
 


### PR DESCRIPTION
## Description

Fix incorrect link to setup wizard.


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor / Chore

## Technical Details
- **Database changes:** No
- **Storage backend affected:** No
- **Usage of AI:** No

## How Has This Been Tested?
- [ ] **Manual Testing:** (e.g., "Uploaded a file using S3 and verified expiration")
- [ ] **Unit Tests:** `go test ./...`
- [ ] **Environment:** (e.g., Docker, Linux, Windows)

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
