### PR TITLE
Remove old Password entry from automatic deployment documentation

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -550,7 +550,7 @@ Stores the access data for cloud storage. This can be reused without modificatio
 config.json
 ------------------------
 
-Contains the server configuration. If you want to deploy Gokapi in multiple instances for redundancy  (e.g. all instances share the same data), then the configuration file can be reused without modification. Otherwise you need to modify it before deploying (see below). Can be read-only, but might need write access when upgrading Gokapi to a newer version. Needs write access when re-running setup or changing the admin password.
+Contains the server configuration. If you want to deploy Gokapi in multiple instances for redundancy  (e.g. all instances share the same data), then the configuration file can be reused without modification. Otherwise you need to modify it before deploying (see below). Can be read-only, but might need write access when upgrading Gokapi to a newer version. Needs write access when re-running setup.
 
 
 Modifying config.json to deploy without setup
@@ -573,7 +573,7 @@ If you want to deploy Gokapi to multiple instances that contain different data, 
 Setting an admin password
 ====================================================
 
-If you are using internal username/password authentication, run the binary with the parameter ``--deployment-password [YOUR_PASSWORD]``. This sets the password and also generates a new salt for the password. This has to be done before Gokapi is run for the first time on the new instance. Alternatively you can do this on the orchestrating machine and then copy the configuration file to the new instance.
+If you are using internal username/password authentication, run the binary with the parameter ``--deployment-password [YOUR_PASSWORD]``. This sets the password and also generates a new salt for the password. This has to be done before Gokapi is run for the first time on the new instance. Alternatively you can do this on the orchestrating machine and then copy the configuration file and database to the new instance.
 
 If you are using a Docker image, this has to be done by starting a container with the entrypoint ``/app/run.sh``, for example: ::
 


### PR DESCRIPTION
Unused field (removed by Gokapi when it re-creates config.json). Seems to be left after migration to multi-user support.

## Description


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor / Chore

## Technical Details
- **Database changes:** No
- **Storage backend affected:** No
- **Usage of AI:** No

## How Has This Been Tested?
- [ ] **Manual Testing:** (e.g., "Uploaded a file using S3 and verified expiration")
- [ ] **Unit Tests:** `go test ./...`
- [ ] **Environment:** (e.g., Docker, Linux, Windows)

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
