### PR TITLE
fix: set MinPasswordLength in reconfiguration setup view

### DIFF
--- a/internal/configuration/setup/Setup.go
+++ b/internal/configuration/setup/Setup.go
@@ -741,6 +741,7 @@ func (v *setupView) loadFromConfig() {
 	}
 	env := environment.New()
 	v.S3EnvProvided = env.IsAwsProvided()
+	v.MinPasswordLength = env.MinLengthPassword
 
 	dbSettings, err := database.ParseUrl(settings.DatabaseUrl, false)
 	helper.Check(err)


### PR DESCRIPTION
## Description
`loadFromConfig()` only set `MinPasswordLength` in the initial-setup path, so the reconfiguration UI rendered password fields with `data-min=0`, bypassing client-side minimum-length validation. (Found during investigation of #370.)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / Chore

## Technical Details
- **Database changes:** No
- **Storage backend affected:** No
- **Usage of AI:** Yes - Bug investigation, fix implementation, and commit messages were assisted

## How Has This Been Tested?
- [x] **Manual Testing:** Set `GOKAPI_MIN_LENGTH_PASSWORD=16`, ran --reconfigure, and confirmed the password field enforces 16-char minimum
- [x] **Unit Tests:** `go test -tags test ./internal/configuration/setup/`
- [x] **Environment:** Docker (Podman Compose), Linux

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
