### PR TITLE
Fix API downloads ignoring ProxyDownload configuration

### DIFF
--- a/internal/storage/FileServing_test.go
+++ b/internal/storage/FileServing_test.go
@@ -600,6 +600,16 @@ func TestServeFile(t *testing.T) {
 		} else {
 			test.ResponseBodyContains(t, w, "<a href=\"http")
 		}
+		r = httptest.NewRequest("GET", "/", nil)
+		w = httptest.NewRecorder()
+		file, result = GetFile("awsTest1234567890123")
+		test.IsEqualBool(t, result, true)
+		ServeFile(file, w, r, false, true, true)
+		if aws.IsMockApi {
+			test.ResponseBodyContains(t, w, "https://redirect.url")
+		} else {
+			test.ResponseBodyContains(t, w, "<a href=\"http")
+		}
 		testconfiguration.DisableS3()
 	}
 	newFile, err := createTestFile()

--- a/internal/storage/filesystem/s3filesystem/aws/Aws.go
+++ b/internal/storage/filesystem/s3filesystem/aws/Aws.go
@@ -148,11 +148,15 @@ func Stream(writer io.Writer, file models.File) error {
 // ServeFile either redirects the user to a pre-signed download url (default) or downloads the file and serves it as a proxy (depending
 // on configuration). Returns true if blocking operation (to set download status) or false if non-blocking.
 func ServeFile(w http.ResponseWriter, r *http.Request, file models.File, forceDownload, forceDecryption bool) (bool, error) {
-	if forceDecryption {
-		return true, serveDecryptedFile(w, file)
-	}
+	needsDecryption := forceDecryption && file.Encryption.IsEncrypted
 	if awsConfig.ProxyDownload {
+		if needsDecryption {
+			return true, serveDecryptedFile(w, file)
+		}
 		return true, proxyDownload(w, file, forceDownload)
+	}
+	if needsDecryption {
+		return true, serveDecryptedFile(w, file)
 	}
 	return false, redirectToDownload(w, r, file, forceDownload)
 }


### PR DESCRIPTION
Fixes #375

API downloads were always being proxied regardless of the ProxyDownload configuration. The issue was that forceDecryption was checked before the ProxyDownload config, causing it to return early and never evaluate the setting.

Updated the logic to only force decryption when the file is actually encrypted (forceDecryption && file.Encryption.IsEncrypted). This lets the ProxyDownload configuration work as intended for API calls.

Added a test case that covers this scenario to make sure both paths work correctly.