### PR TITLE
Improve og tags in download view

### DIFF
--- a/internal/webserver/Webserver.go
+++ b/internal/webserver/Webserver.go
@@ -552,6 +552,51 @@ type LoginView struct {
 	CustomContent  customStatic
 }
 
+func formatAvailability(expiryUnix int64) string {
+	now := time.Now().UTC()
+	expiry := time.Unix(expiryUnix, 0).UTC()
+
+	if expiry.Before(now) {
+		return "expired"
+	}
+
+	diff := expiry.Sub(now)
+
+	minute := time.Minute
+	hour := time.Hour
+	day := 24 * hour
+	week := 7 * day
+	month := 4 * week
+
+	switch {
+	case diff >= month:
+		m := int(diff / month)
+		return pluralize(m, "month")
+	case diff >= week:
+		w := int(diff / week)
+		return pluralize(w, "week")
+	case diff >= day:
+		d := int(diff / day)
+		return pluralize(d, "day")
+	case diff >= hour:
+		h := int(diff / hour)
+		return pluralize(h, "hour")
+	default:
+		m := int(diff / minute)
+		if m < 1 {
+			m = 1
+		}
+		return pluralize(m, "minute")
+	}
+}
+
+func pluralize(value int, unit string) string {
+	if value == 1 {
+		return fmt.Sprintf("1 %s", unit)
+	}
+	return fmt.Sprintf("%d %ss", value, unit)
+}
+
 // Handling of /d
 // Checks if a file exists for the submitted ID
 // If it exists, a download form is shown, or a password needs to be entered.
@@ -576,6 +621,7 @@ func showDownload(w http.ResponseWriter, r *http.Request) {
 		BaseUrl:            config.ServerUrl,
 		IsFailedLogin:      false,
 		UsesHttps:          configuration.UsesHttps(),
+		AvailableForString: formatAvailability(file.ExpireAt),
 		CustomContent:      customStaticInfo,
 	}
 
@@ -728,6 +774,7 @@ type DownloadView struct {
 	EndToEndEncryption   bool
 	UsesHttps            bool
 	CustomContent        customStatic
+	AvailableForString   string
 }
 
 type e2ESetupView struct {

--- a/internal/webserver/web/templates/html_header.tmpl
+++ b/internal/webserver/web/templates/html_header.tmpl
@@ -51,8 +51,8 @@
 	  <meta name="title" content="{{.PublicName}}: {{.Name}}">
     	  <meta name="description" content="{{.Size}}">
     	  
-    	  <meta property="og:title" content="{{.Name}}"/>
-  	  <meta property="og:description" content="{{.Size}}"/>
+    	  <meta property="og:title" content="Download your file {{.Name}} now from {{.PublicName}}."/>
+  	  <meta property="og:description" content="Your file {{.Name}} ({{.Size}}) is now ready to download from {{.PublicName}}. Available for {{.AvailableForString}}."/>
        {{end }}
   	  <meta property="og:url" content="{{.BaseUrl}}"/>
    {{ else }}


### PR DESCRIPTION
## Description
Improves the download view of a file by adding more descriptive `og:title` and `og:description`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / Chore

## Technical Details
- **Database changes:** No
- **Storage backend affected:** No
- **Usage of AI:** No

## How Has This Been Tested?
- [x] **Manual Testing:** view in Browser
- [ ] **Unit Tests:** `go test ./...`
- [x] **Environment:** Linux (Ubuntu)

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
