### PR TITLE
Use Go cross-compile for Docker image building workflow, add risc-v support for Docker, update Go to 1.26.2 and Alpine to 3.23

### DIFF
--- a/.github/workflows/docker-publish-cli-multiarch-release-custom.yml
+++ b/.github/workflows/docker-publish-cli-multiarch-release-custom.yml
@@ -28,4 +28,4 @@ jobs:
         run: echo "${{ secrets.DOCKER_PW }}" | docker login -u "${{ secrets.DOCKER_USER }}" --password-stdin
       - name: build and push the image
         run: |
-          docker buildx build -f Dockerfile.cli-tool --push --tag f0rc3/gokapi-cli:${{ github.event.inputs.tagname }} --platform linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64 .
+          docker buildx build -f Dockerfile.cli-tool --push --tag f0rc3/gokapi-cli:${{ github.event.inputs.tagname }} --platform linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/arm64,linux/riscv64 .

--- a/.github/workflows/docker-publish-multiarch-dev.yml
+++ b/.github/workflows/docker-publish-multiarch-dev.yml
@@ -79,20 +79,30 @@ jobs:
 
           for platform in "${!PLATFORMS[@]}"; do
             binary="${PLATFORMS[$platform]}"
-            tag="f0rc3/gokapi:latest-dev-${binary}"
             echo "Building $platform with binary $binary..."
             docker buildx build \
               --push \
               --platform "$platform" \
               --build-arg BINARY_NAME="$binary" \
-              --tag "$tag" \
+              --tag "f0rc3/gokapi:tmp-dev-${binary}" \
               --file Dockerfile.multiarch \
               .
           done
 
           docker buildx imagetools create \
             --tag f0rc3/gokapi:latest-dev \
-            $(for platform in "${!PLATFORMS[@]}"; do
-                binary="${PLATFORMS[$platform]}"
-                echo "f0rc3/gokapi:latest-dev-${binary}"
+            $(for binary in "${PLATFORMS[@]}"; do
+                echo "f0rc3/gokapi:tmp-dev-${binary}"
               done)
+
+          # Delete intermediate tags
+          TOKEN=$(curl -s -X POST \
+            -H "Content-Type: application/json" \
+            -d "{\"username\": \"${{ secrets.DOCKER_USER }}\", \"password\": \"${{ secrets.DOCKER_PW }}\"}" \
+            https://hub.docker.com/v2/users/login/ | jq -r .token)
+
+          for binary in "${PLATFORMS[@]}"; do
+            curl -s -X DELETE \
+              -H "Authorization: JWT ${TOKEN}" \
+              "https://hub.docker.com/v2/repositories/f0rc3/gokapi/tags/tmp-dev-${binary}/"
+          done

--- a/.github/workflows/docker-publish-multiarch-dev.yml
+++ b/.github/workflows/docker-publish-multiarch-dev.yml
@@ -66,12 +66,33 @@ jobs:
 
       - name: Build and push multi-arch image
         run: |
-          # Create a buildx builder that can push a manifest list
           docker buildx create --use --name multiarch-builder
 
-          docker buildx build \
-            --push \
-            --platform linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/riscv64 \
+          declare -A PLATFORMS=(
+            ["linux/amd64"]="gokapi-amd64"
+            ["linux/386"]="gokapi-386"
+            ["linux/arm64"]="gokapi-arm64"
+            ["linux/arm/v7"]="gokapi-arm-v7"
+            ["linux/arm/v6"]="gokapi-arm-v6"
+            ["linux/riscv64"]="gokapi-riscv64"
+          )
+
+          for platform in "${!PLATFORMS[@]}"; do
+            binary="${PLATFORMS[$platform]}"
+            tag="f0rc3/gokapi:latest-dev-${binary}"
+            echo "Building $platform with binary $binary..."
+            docker buildx build \
+              --push \
+              --platform "$platform" \
+              --build-arg BINARY_NAME="$binary" \
+              --tag "$tag" \
+              --file Dockerfile.multiarch \
+              .
+          done
+
+          docker buildx imagetools create \
             --tag f0rc3/gokapi:latest-dev \
-            --file Dockerfile.multiarch \
-            .
+            $(for platform in "${!PLATFORMS[@]}"; do
+                binary="${PLATFORMS[$platform]}"
+                echo "f0rc3/gokapi:latest-dev-${binary}"
+              done)

--- a/.github/workflows/docker-publish-multiarch-dev.yml
+++ b/.github/workflows/docker-publish-multiarch-dev.yml
@@ -14,20 +14,64 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: checkout code
+      - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: install buildx
-        id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v1
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          version: latest
-      - name: login to docker hub
+          go-version-file: go.mod
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
         run: echo "${{ secrets.DOCKER_PW }}" | docker login -u "${{ secrets.DOCKER_USER }}" --password-stdin
-      - name: build the image
+
+      - name: Cross-compile binaries
         run: |
-          docker buildx build --tag f0rc3/gokapi:latest --platform linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64 .
-      - name: push the image
+          BUILD_FLAGS="-ldflags=-s -w \
+            -X 'github.com/forceu/gokapi/internal/environment.IsDocker=true' \
+            -X 'github.com/forceu/gokapi/internal/environment.Builder=Project Docker File' \
+            -X 'github.com/forceu/gokapi/internal/environment.BuildTime=$(date)'"
+
+          go generate ./...
+
+          declare -A TARGETS=(
+            ["linux/amd64"]="amd64"
+            ["linux/386"]="386"
+            ["linux/arm64"]="arm64"
+            ["linux/arm/v7"]="arm v7"
+            ["linux/arm/v6"]="arm v6"
+            ["linux/riscv64"]=""
+          )
+
+          for platform in "${!TARGETS[@]}"; do
+            OS="${platform%%/*}"
+            REST="${platform#*/}"
+            ARCH="${REST%%/*}"
+            VARIANT="${REST##*/}"
+            [ "$VARIANT" = "$ARCH" ] && VARIANT=""
+            GOARM=""
+            [ -n "$VARIANT" ] && GOARM="${VARIANT//v/}"
+            OUT="bin/gokapi-${ARCH}${VARIANT:+-$VARIANT}"
+            echo "Building $OUT (GOARCH=$ARCH GOARM=$GOARM)..."
+            CGO_ENABLED=0 GOOS=$OS GOARCH=$ARCH GOARM=$GOARM \
+              go build $BUILD_FLAGS -o "$OUT" github.com/forceu/gokapi/cmd/gokapi &
+          done
+          wait
+          echo "All binaries built."
+
+      - name: Build and push multi-arch image
         run: |
-          docker buildx build --push --tag f0rc3/gokapi:latest-dev --platform linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64 .
+          # Create a buildx builder that can push a manifest list
+          docker buildx create --use --name multiarch-builder
+
+          docker buildx build \
+            --push \
+            --platform linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/riscv64 \
+            --tag f0rc3/gokapi:latest-dev \
+            --file Dockerfile.multiarch \
+            .

--- a/.github/workflows/docker-publish-multiarch-dev.yml
+++ b/.github/workflows/docker-publish-multiarch-dev.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Cross-compile binaries
         run: |
-          BUILD_FLAGS="-ldflags=-s -w \
+          LDFLAGS="-s -w \
             -X 'github.com/forceu/gokapi/internal/environment.IsDocker=true' \
             -X 'github.com/forceu/gokapi/internal/environment.Builder=Project Docker File' \
             -X 'github.com/forceu/gokapi/internal/environment.BuildTime=$(date)'"
@@ -40,11 +40,11 @@ jobs:
           go generate ./...
 
           declare -A TARGETS=(
-            ["linux/amd64"]="amd64"
-            ["linux/386"]="386"
-            ["linux/arm64"]="arm64"
-            ["linux/arm/v7"]="arm v7"
-            ["linux/arm/v6"]="arm v6"
+            ["linux/amd64"]=""
+            ["linux/386"]=""
+            ["linux/arm64"]=""
+            ["linux/arm/v7"]=""
+            ["linux/arm/v6"]=""
             ["linux/riscv64"]=""
           )
 
@@ -59,7 +59,7 @@ jobs:
             OUT="bin/gokapi-${ARCH}${VARIANT:+-$VARIANT}"
             echo "Building $OUT (GOARCH=$ARCH GOARM=$GOARM)..."
             CGO_ENABLED=0 GOOS=$OS GOARCH=$ARCH GOARM=$GOARM \
-              go build $BUILD_FLAGS -o "$OUT" github.com/forceu/gokapi/cmd/gokapi &
+              go build -ldflags "$LDFLAGS" -o "$OUT" github.com/forceu/gokapi/cmd/gokapi &
           done
           wait
           echo "All binaries built."

--- a/.github/workflows/docker-publish-multiarch-release-custom.yml
+++ b/.github/workflows/docker-publish-multiarch-release-custom.yml
@@ -68,13 +68,36 @@ jobs:
           wait
           echo "All binaries built."
 
+
       - name: Build and push multi-arch image
         run: |
           docker buildx create --use --name multiarch-builder
 
-          docker buildx build \
-            --push \
-            --platform linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/riscv64 \
+          declare -A PLATFORMS=(
+            ["linux/amd64"]="gokapi-amd64"
+            ["linux/386"]="gokapi-386"
+            ["linux/arm64"]="gokapi-arm64"
+            ["linux/arm/v7"]="gokapi-arm-v7"
+            ["linux/arm/v6"]="gokapi-arm-v6"
+            ["linux/riscv64"]="gokapi-riscv64"
+          )
+
+          for platform in "${!PLATFORMS[@]}"; do
+            binary="${PLATFORMS[$platform]}"
+            tag="f0rc3/gokapi:latest-dev-${binary}"
+            echo "Building $platform with binary $binary..."
+            docker buildx build \
+              --push \
+              --platform "$platform" \
+              --build-arg BINARY_NAME="$binary" \
+              --tag "$tag" \
+              --file Dockerfile.multiarch \
+              .
+          done
+
+          docker buildx imagetools create \
             --tag f0rc3/gokapi:${{ github.event.inputs.tagname }} \
-            --file Dockerfile.multiarch \
-            .
+            $(for platform in "${!PLATFORMS[@]}"; do
+                binary="${PLATFORMS[$platform]}"
+                echo "f0rc3/gokapi:latest-dev-${binary}"
+              done)

--- a/.github/workflows/docker-publish-multiarch-release-custom.yml
+++ b/.github/workflows/docker-publish-multiarch-release-custom.yml
@@ -84,13 +84,12 @@ jobs:
 
           for platform in "${!PLATFORMS[@]}"; do
             binary="${PLATFORMS[$platform]}"
-            tag="f0rc3/gokapi:latest-dev-${binary}"
             echo "Building $platform with binary $binary..."
             docker buildx build \
               --push \
               --platform "$platform" \
               --build-arg BINARY_NAME="$binary" \
-              --tag "$tag" \
+              --tag "f0rc3/gokapi:tmp-${binary}" \
               --file Dockerfile.multiarch \
               .
           done
@@ -99,5 +98,17 @@ jobs:
             --tag f0rc3/gokapi:${{ github.event.inputs.tagname }} \
             $(for platform in "${!PLATFORMS[@]}"; do
                 binary="${PLATFORMS[$platform]}"
-                echo "f0rc3/gokapi:latest-dev-${binary}"
+                echo "f0rc3/gokapi:tmp-${binary}"
               done)
+
+          # Delete intermediate tags
+          TOKEN=$(curl -s -X POST \
+            -H "Content-Type: application/json" \
+            -d "{\"username\": \"${{ secrets.DOCKER_USER }}\", \"password\": \"${{ secrets.DOCKER_PW }}\"}" \
+            https://hub.docker.com/v2/users/login/ | jq -r .token)
+
+          for binary in "${PLATFORMS[@]}"; do
+            curl -s -X DELETE \
+              -H "Authorization: JWT ${TOKEN}" \
+              "https://hub.docker.com/v2/repositories/f0rc3/gokapi/tags/tmp-${binary}/"
+          done

--- a/.github/workflows/docker-publish-multiarch-release-custom.yml
+++ b/.github/workflows/docker-publish-multiarch-release-custom.yml
@@ -7,26 +7,74 @@ on:
         description: 'Tag name to be built'
         required: true
 
-
 permissions:
   contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
+
     steps:
-      - name: checkout code
+      - name: Checkout code
         uses: actions/checkout@v4
         with:
-            fetch-depth: 0
-      - run: git checkout tags/${{ github.event.inputs.tagname }}
-      - name: install buildx
-        id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v1
+          fetch-depth: 0
+
+      - name: Checkout requested tag
+        run: git checkout tags/${{ github.event.inputs.tagname }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          version: latest
-      - name: login to docker hub
+          go-version-file: go.mod
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
         run: echo "${{ secrets.DOCKER_PW }}" | docker login -u "${{ secrets.DOCKER_USER }}" --password-stdin
-      - name: build and push the image
+
+      - name: Cross-compile binaries
         run: |
-          docker buildx build --push --tag f0rc3/gokapi:${{ github.event.inputs.tagname }} --platform linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64 .
+          BUILD_FLAGS="-ldflags=-s -w \
+            -X 'github.com/forceu/gokapi/internal/environment.IsDocker=true' \
+            -X 'github.com/forceu/gokapi/internal/environment.Builder=Project Docker File' \
+            -X 'github.com/forceu/gokapi/internal/environment.BuildTime=$(date)'"
+
+          go generate ./...
+
+          declare -A TARGETS=(
+            ["linux/amd64"]=""
+            ["linux/386"]=""
+            ["linux/arm64"]=""
+            ["linux/arm/v7"]=""
+            ["linux/arm/v6"]=""
+            ["linux/riscv64"]=""
+          )
+
+          for platform in "${!TARGETS[@]}"; do
+            OS="${platform%%/*}"
+            REST="${platform#*/}"
+            ARCH="${REST%%/*}"
+            VARIANT="${REST##*/}"
+            [ "$VARIANT" = "$ARCH" ] && VARIANT=""
+            GOARM=""
+            [ -n "$VARIANT" ] && GOARM="${VARIANT//v/}"
+            OUT="bin/gokapi-${ARCH}${VARIANT:+-$VARIANT}"
+            echo "Building $OUT (GOARCH=$ARCH GOARM=$GOARM)..."
+            CGO_ENABLED=0 GOOS=$OS GOARCH=$ARCH GOARM=$GOARM \
+              go build $BUILD_FLAGS -o "$OUT" github.com/forceu/gokapi/cmd/gokapi &
+          done
+          wait
+          echo "All binaries built."
+
+      - name: Build and push multi-arch image
+        run: |
+          docker buildx create --use --name multiarch-builder
+
+          docker buildx build \
+            --push \
+            --platform linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/riscv64 \
+            --tag f0rc3/gokapi:${{ github.event.inputs.tagname }} \
+            --file Dockerfile.multiarch \
+            .

--- a/.github/workflows/docker-publish-multiarch-release-custom.yml
+++ b/.github/workflows/docker-publish-multiarch-release-custom.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Cross-compile binaries
         run: |
-          BUILD_FLAGS="-ldflags=-s -w \
+          LDFLAGS="-s -w \
             -X 'github.com/forceu/gokapi/internal/environment.IsDocker=true' \
             -X 'github.com/forceu/gokapi/internal/environment.Builder=Project Docker File' \
             -X 'github.com/forceu/gokapi/internal/environment.BuildTime=$(date)'"
@@ -63,7 +63,7 @@ jobs:
             OUT="bin/gokapi-${ARCH}${VARIANT:+-$VARIANT}"
             echo "Building $OUT (GOARCH=$ARCH GOARM=$GOARM)..."
             CGO_ENABLED=0 GOOS=$OS GOARCH=$ARCH GOARM=$GOARM \
-              go build $BUILD_FLAGS -o "$OUT" github.com/forceu/gokapi/cmd/gokapi &
+              go build -ldflags "$LDFLAGS" -o "$OUT" github.com/forceu/gokapi/cmd/gokapi &
           done
           wait
           echo "All binaries built."

--- a/.github/workflows/docker-publish-multiarch-release.yml
+++ b/.github/workflows/docker-publish-multiarch-release.yml
@@ -5,38 +5,80 @@ on:
   release:
     types: [released]
 
-
 permissions:
   contents: read
-
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: oprypin/find-latest-tag@v1
+      - name: Find latest release tag
+        uses: oprypin/find-latest-tag@v1
         with:
-          repository: Forceu/Gokapi 
-          releases-only: true 
+          repository: Forceu/Gokapi
+          releases-only: true
           prefix: 'v'
         id: latestversion
 
-      - name: checkout code
+      - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: install buildx
-        id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v1
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          version: latest
-      - name: login to docker hub
+          go-version-file: go.mod
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
         run: echo "${{ secrets.DOCKER_PW }}" | docker login -u "${{ secrets.DOCKER_USER }}" --password-stdin
-      - name: build the image
+
+      - name: Cross-compile binaries
         run: |
-          docker buildx build --tag f0rc3/gokapi:latest --platform linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64 .
-      - name: push the image
+          BUILD_FLAGS="-ldflags=-s -w \
+            -X 'github.com/forceu/gokapi/internal/environment.IsDocker=true' \
+            -X 'github.com/forceu/gokapi/internal/environment.Builder=Project Docker File' \
+            -X 'github.com/forceu/gokapi/internal/environment.BuildTime=$(date)'"
+
+          go generate ./...
+
+          declare -A TARGETS=(
+            ["linux/amd64"]=""
+            ["linux/386"]=""
+            ["linux/arm64"]=""
+            ["linux/arm/v7"]=""
+            ["linux/arm/v6"]=""
+            ["linux/riscv64"]=""
+          )
+
+          for platform in "${!TARGETS[@]}"; do
+            OS="${platform%%/*}"
+            REST="${platform#*/}"
+            ARCH="${REST%%/*}"
+            VARIANT="${REST##*/}"
+            [ "$VARIANT" = "$ARCH" ] && VARIANT=""
+            GOARM=""
+            [ -n "$VARIANT" ] && GOARM="${VARIANT//v/}"
+            OUT="bin/gokapi-${ARCH}${VARIANT:+-$VARIANT}"
+            echo "Building $OUT (GOARCH=$ARCH GOARM=$GOARM)..."
+            CGO_ENABLED=0 GOOS=$OS GOARCH=$ARCH GOARM=$GOARM \
+              go build $BUILD_FLAGS -o "$OUT" github.com/forceu/gokapi/cmd/gokapi &
+          done
+          wait
+          echo "All binaries built."
+
+      - name: Build and push multi-arch image (latest + version tag)
         run: |
-          docker buildx build --push --tag f0rc3/gokapi:latest --platform linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64 .
-          docker buildx build --push --tag f0rc3/gokapi:${{ steps.latestversion.outputs.tag }} --platform linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64 .
+          docker buildx create --use --name multiarch-builder
+
+          docker buildx build \
+            --push \
+            --platform linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/riscv64 \
+            --tag f0rc3/gokapi:latest \
+            --tag f0rc3/gokapi:${{ steps.latestversion.outputs.tag }} \
+            --file Dockerfile.multiarch \
+            .

--- a/.github/workflows/docker-publish-multiarch-release.yml
+++ b/.github/workflows/docker-publish-multiarch-release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Cross-compile binaries
         run: |
-          BUILD_FLAGS="-ldflags=-s -w \
+          LDFLAGS="-s -w \
             -X 'github.com/forceu/gokapi/internal/environment.IsDocker=true' \
             -X 'github.com/forceu/gokapi/internal/environment.Builder=Project Docker File' \
             -X 'github.com/forceu/gokapi/internal/environment.BuildTime=$(date)'"
@@ -66,7 +66,7 @@ jobs:
             OUT="bin/gokapi-${ARCH}${VARIANT:+-$VARIANT}"
             echo "Building $OUT (GOARCH=$ARCH GOARM=$GOARM)..."
             CGO_ENABLED=0 GOOS=$OS GOARCH=$ARCH GOARM=$GOARM \
-              go build $BUILD_FLAGS -o "$OUT" github.com/forceu/gokapi/cmd/gokapi &
+              go build -ldflags "$LDFLAGS" -o "$OUT" github.com/forceu/gokapi/cmd/gokapi &
           done
           wait
           echo "All binaries built."

--- a/.github/workflows/docker-publish-multiarch-release.yml
+++ b/.github/workflows/docker-publish-multiarch-release.yml
@@ -71,14 +71,35 @@ jobs:
           wait
           echo "All binaries built."
 
-      - name: Build and push multi-arch image (latest + version tag)
+      - name: Build and push multi-arch image
         run: |
           docker buildx create --use --name multiarch-builder
 
-          docker buildx build \
-            --push \
-            --platform linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/riscv64 \
+          declare -A PLATFORMS=(
+            ["linux/amd64"]="gokapi-amd64"
+            ["linux/386"]="gokapi-386"
+            ["linux/arm64"]="gokapi-arm64"
+            ["linux/arm/v7"]="gokapi-arm-v7"
+            ["linux/arm/v6"]="gokapi-arm-v6"
+            ["linux/riscv64"]="gokapi-riscv64"
+          )
+
+          for platform in "${!PLATFORMS[@]}"; do
+            binary="${PLATFORMS[$platform]}"
+            tag="f0rc3/gokapi:latest-dev-${binary}"
+            echo "Building $platform with binary $binary..."
+            docker buildx build \
+              --push \
+              --platform "$platform" \
+              --build-arg BINARY_NAME="$binary" \
+              --tag "$tag" \
+              --file Dockerfile.multiarch \
+              .
+          done
+
+          docker buildx imagetools create \
             --tag f0rc3/gokapi:latest \
-            --tag f0rc3/gokapi:${{ steps.latestversion.outputs.tag }} \
-            --file Dockerfile.multiarch \
-            .
+            $(for platform in "${!PLATFORMS[@]}"; do
+                binary="${PLATFORMS[$platform]}"
+                echo "f0rc3/gokapi:latest-dev-${binary}"
+              done)

--- a/.github/workflows/docker-publish-multiarch-release.yml
+++ b/.github/workflows/docker-publish-multiarch-release.yml
@@ -86,13 +86,11 @@ jobs:
 
           for platform in "${!PLATFORMS[@]}"; do
             binary="${PLATFORMS[$platform]}"
-            tag="f0rc3/gokapi:latest-dev-${binary}"
             echo "Building $platform with binary $binary..."
             docker buildx build \
-              --push \
               --platform "$platform" \
               --build-arg BINARY_NAME="$binary" \
-              --tag "$tag" \
+              --tag "f0rc3/gokapi:tmp-cu-${binary}" \
               --file Dockerfile.multiarch \
               .
           done
@@ -101,5 +99,17 @@ jobs:
             --tag f0rc3/gokapi:latest \
             $(for platform in "${!PLATFORMS[@]}"; do
                 binary="${PLATFORMS[$platform]}"
-                echo "f0rc3/gokapi:latest-dev-${binary}"
+                echo "f0rc3/gokapi:tmp-cu-${binary}"
               done)
+
+          # Delete intermediate tags
+          TOKEN=$(curl -s -X POST \
+            -H "Content-Type: application/json" \
+            -d "{\"username\": \"${{ secrets.DOCKER_USER }}\", \"password\": \"${{ secrets.DOCKER_PW }}\"}" \
+            https://hub.docker.com/v2/users/login/ | jq -r .token)
+
+          for binary in "${PLATFORMS[@]}"; do
+            curl -s -X DELETE \
+              -H "Authorization: JWT ${TOKEN}" \
+              "https://hub.docker.com/v2/repositories/f0rc3/gokapi/tags/tmp-cu-${binary}/"
+          done

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-alpine AS build_base
+FROM golang:1.26.2-alpine AS build_base
 
 ## Usage:
 ## docker build . -t gokapi
@@ -9,7 +9,7 @@ COPY . /compile
 RUN cd /compile && go generate ./... && CGO_ENABLED=0 go build -ldflags="-s -w -X 'github.com/forceu/gokapi/internal/environment.IsDocker=true' -X 'github.com/forceu/gokapi/internal/environment.Builder=Project Docker File' -X 'github.com/forceu/gokapi/internal/environment.BuildTime=$(date)'" -o /compile/gokapi github.com/forceu/gokapi/cmd/gokapi
 
 
-FROM alpine:3.19
+FROM alpine:3.23
 
 RUN addgroup -S gokapi && adduser -S gokapi -G gokapi
 RUN apk update && apk add --no-cache su-exec tini ca-certificates curl tzdata && \

--- a/Dockerfile.cli-tool
+++ b/Dockerfile.cli-tool
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-alpine AS build_base
+FROM golang:1.26.2-alpine AS build_base
 
 ## Usage:
 ## docker build . -f Dockerfile.cli-tool -t gokapi-cli
@@ -12,7 +12,7 @@ COPY . /compile
 
 RUN cd /compile && go generate ./... && CGO_ENABLED=0 go build -ldflags="-s -w -X 'github.com/forceu/gokapi/internal/environment.IsDocker=true' -X 'github.com/forceu/gokapi/internal/environment.Builder=Project Docker File' -X 'github.com/forceu/gokapi/internal/environment.BuildTime=$(date)'" -o /compile/gokapi-cli github.com/forceu/gokapi/cmd/cli-uploader
 
-FROM alpine:3.19
+FROM alpine:3.23
 
 COPY --from=build_base /compile/gokapi-cli /app/gokapi-cli
 WORKDIR /app

--- a/Dockerfile.multiarch
+++ b/Dockerfile.multiarch
@@ -12,10 +12,16 @@ RUN apk update && apk add --no-cache su-exec tini ca-certificates curl tzdata &&
 
 COPY dockerentry.sh /app/run.sh
 
-# Copy the pre-built binary that matches this platform
-COPY bin/gokapi-${TARGETARCH}${TARGETVARIANT:+-$TARGETVARIANT} /app/gokapi
+COPY bin/ /tmp/bin/
 
-RUN chmod +x /app/gokapi /app/run.sh
+# Select the correct binary for this platform
+RUN if [ -n "$TARGETVARIANT" ]; then \
+      cp /tmp/bin/gokapi-${TARGETARCH}-${TARGETVARIANT} /app/gokapi; \
+    else \
+      cp /tmp/bin/gokapi-${TARGETARCH} /app/gokapi; \
+    fi && \
+    chmod +x /app/gokapi /app/run.sh && \
+    rm -rf /tmp/bin
 
 WORKDIR /app
 

--- a/Dockerfile.multiarch
+++ b/Dockerfile.multiarch
@@ -1,0 +1,25 @@
+## Used by Github workflow for publishing Docker image.
+
+FROM alpine:3.23
+
+# Passed in automatically by buildx for each platform
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+RUN addgroup -S gokapi && adduser -S gokapi -G gokapi
+RUN apk update && apk add --no-cache su-exec tini ca-certificates curl tzdata && \
+    mkdir /app && touch /app/.isdocker
+
+COPY dockerentry.sh /app/run.sh
+
+# Copy the pre-built binary that matches this platform
+COPY bin/gokapi-${TARGETARCH}${TARGETVARIANT:+-$TARGETVARIANT} /app/gokapi
+
+RUN chmod +x /app/gokapi /app/run.sh
+
+WORKDIR /app
+
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["/app/run.sh"]
+HEALTHCHECK --interval=10s --timeout=5s --retries=3 \
+  CMD curl --fail http://127.0.0.1:53842 || exit 1

--- a/Dockerfile.multiarch
+++ b/Dockerfile.multiarch
@@ -11,7 +11,6 @@ RUN apk update && apk add --no-cache su-exec tini ca-certificates curl tzdata &&
     mkdir /app && touch /app/.isdocker
 
 COPY dockerentry.sh /app/run.sh
-
 COPY bin/ /tmp/bin/
 
 # Select the correct binary for this platform

--- a/Dockerfile.multiarch
+++ b/Dockerfile.multiarch
@@ -2,25 +2,16 @@
 
 FROM alpine:3.23
 
-# Passed in automatically by buildx for each platform
-ARG TARGETARCH
-ARG TARGETVARIANT
+ARG BINARY_NAME
 
 RUN addgroup -S gokapi && adduser -S gokapi -G gokapi
 RUN apk update && apk add --no-cache su-exec tini ca-certificates curl tzdata && \
     mkdir /app && touch /app/.isdocker
 
 COPY dockerentry.sh /app/run.sh
-COPY bin/ /tmp/bin/
+COPY bin/${BINARY_NAME} /app/gokapi
 
-# Select the correct binary for this platform
-RUN if [ -n "$TARGETVARIANT" ]; then \
-      cp /tmp/bin/gokapi-${TARGETARCH}-${TARGETVARIANT} /app/gokapi; \
-    else \
-      cp /tmp/bin/gokapi-${TARGETARCH} /app/gokapi; \
-    fi && \
-    chmod +x /app/gokapi /app/run.sh && \
-    rm -rf /tmp/bin
+RUN chmod +x /app/gokapi /app/run.sh
 
 WORKDIR /app
 


### PR DESCRIPTION
Reduces the image building time by a factor of 10