### PR TITLE
Version is obsolete in Docker Compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.3'
 services:
   gokapi:
     image: f0rc3/gokapi:latest


### PR DESCRIPTION
## Description
The version tag in Docker Compose is obsolete and will produce a warning if left in the docker-compose file.
I have removed it.

## Type of Change
- [x ] Bug fix (non-breaking change which fixes an issue)

## Technical Details
- **Database changes:** No
- **Storage backend affected:** No
- **Usage of AI:** No

## How Has This Been Tested?
No need to, as its a very very very minor thing, that will not break anything

## Checklist
- [ x] I have performed a self-review of my own code.
- [x ] I have commented my code, particularly in hard-to-understand areas.
- [x ] I have made corresponding changes to the documentation.
- [x ] My changes generate no new warnings.
