### PR TITLE
fix: delete the previous content when a file is replaced

### DIFF
--- a/internal/storage/FileServing.go
+++ b/internal/storage/FileServing.go
@@ -384,6 +384,7 @@ func ReplaceFile(fileId, newFileContentId string, delete bool) (models.File, err
 		return models.File{}, ErrorReplaceE2EFile
 	}
 
+	previousContent := file
 	file.Name = newFileContent.Name
 	file.Size = newFileContent.Size
 	file.SHA1 = newFileContent.SHA1
@@ -392,10 +393,25 @@ func ReplaceFile(fileId, newFileContentId string, delete bool) (models.File, err
 	file.SizeBytes = newFileContent.SizeBytes
 	file.Encryption = newFileContent.Encryption
 	database.SaveMetaData(file)
+	deleteUnreferencedSource(previousContent)
 	if delete {
 		DeleteFile(newFileContent.Id, true)
 	}
 	return file, nil
+}
+
+// deleteUnreferencedSource deletes the stored data of a file that no metadata entry points at anymore.
+// CleanUp only reaches sources that are still referenced by an entry, so the content a replaced file
+// used to hold would otherwise stay in storage for good.
+func deleteUnreferencedSource(file models.File) {
+	for _, metadata := range database.GetAllMetadata() {
+		if metadata.SHA1 == file.SHA1 {
+			return
+		}
+	}
+	if FileExists(file, configuration.Get().DataDir) {
+		deleteSource(file, configuration.Get().DataDir)
+	}
 }
 
 func isChangeRequested(parametersToChange, parameter int) bool {

--- a/internal/storage/FileServing_test.go
+++ b/internal/storage/FileServing_test.go
@@ -895,6 +895,44 @@ func TestReplaceFile(t *testing.T) {
 	_, ok = GetFile(newFile.Id)
 	test.IsEqualBool(t, ok, false)
 }
+func TestReplaceFileDeletesPreviousContent(t *testing.T) {
+	dataDir := configuration.Get().DataDir
+	previousSha1 := "replacedoldcontent"
+	newSha1 := "replacednewcontent"
+	test.IsNil(t, os.WriteFile(dataDir+"/"+previousSha1, []byte("old"), 0600))
+	test.IsNil(t, os.WriteFile(dataDir+"/"+newSha1, []byte("new"), 0600))
+
+	original := models.File{
+		Id:                 "replacesourceoriginal",
+		Name:               "old.txt",
+		Size:               "3 B",
+		SHA1:               previousSha1,
+		ContentType:        "text/plain",
+		UnlimitedDownloads: true,
+		UnlimitedTime:      true,
+		SizeBytes:          3,
+	}
+	replacement := models.File{
+		Id:                 "replacesourcenew",
+		Name:               "new.txt",
+		Size:               "3 B",
+		SHA1:               newSha1,
+		ContentType:        "text/plain",
+		UnlimitedDownloads: true,
+		UnlimitedTime:      true,
+		SizeBytes:          3,
+	}
+	database.SaveMetaData(original)
+	database.SaveMetaData(replacement)
+
+	_, err := ReplaceFile(original.Id, replacement.Id, false)
+	test.IsNil(t, err)
+
+	_, err = os.Stat(dataDir + "/" + previousSha1)
+	test.IsEqualBool(t, os.IsNotExist(err), true)
+	test.FileExists(t, dataDir+"/"+newSha1)
+}
+
 func TestParallelDownloads(t *testing.T) {
 	const allowedDownloads = 5
 


### PR DESCRIPTION
## Description

Closes #407.

`ReplaceFile` rewrites the existing metadata entry in place, pointing it at the new content's `SHA1`, `AwsBucket` and size. Whatever the file used to hold is then referenced by no entry at all.

`CleanUp` frees a source by walking metadata: for each entry it considers expired or missing it checks whether any other entry shares the same `SHA1`, and only then removes the stored data. Since nothing points at the replaced content any more, `CleanUp` never visits it, so it is never reclaimed. That is why the storage stays occupied whether or not `deleteNewFile` is set: `deleteNewFile` only expires the entry holding the *new* content.

The fix keeps a copy of the entry before it is rewritten and deletes that source afterwards, unless another entry still shares the same `SHA1` (a duplicate, or a replace with identical content).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / Chore

## Technical Details
- **Database changes:** No
- **Storage backend affected:** Both. The deletion goes through the existing `deleteSource`, which already routes to `aws.DeleteObject` for non-local files and keeps the old `AwsBucket` from the copied entry.
- **Usage of AI:** Yes. AI assisted with tracing the `ReplaceFile` -> `CleanUp` path and drafting the test. I confirmed the root cause against the code, decided the approach, and ran the suite myself.

## How Has This Been Tested?
- [x] **Unit Tests:** new `TestReplaceFileDeletesPreviousContent` writes both sources to the data dir, replaces one with the other, and asserts the previous source is gone while the new one remains. It fails on `master` (`Assertion failed, got: false, want: true`) and passes with the change. `TestReplaceFile` still passes.
- [x] **Environment:** Windows, `go test ./internal/storage/... --tags=test,awsmock`.
- Four tests fail identically before and after this change on this host: `TestNewFile`, `TestGetFileByChunkId`, `TestLocalStorageDriver_Init` and `TestGetDataPath`. They look like path-separator assumptions rather than anything related to this change.
- `go vet --tags=test,awsmock ./internal/storage/` and `gofmt -l` clean.

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.