### PR TITLE
Fix flaky tests on Windows

### DIFF
--- a/internal/configuration/setup/Setup_test.go
+++ b/internal/configuration/setup/Setup_test.go
@@ -729,7 +729,11 @@ func TestIsErrorAddressAlreadyInUse(t *testing.T) {
 	l, err := net.Listen("tcp", "127.0.0.1:19888")
 	test.IsNil(t, err)
 	srv2 := http.Server{
-		Addr: ":19888",
+		// Must bind to the exact same address as the listener above, not just
+		// the same port on all interfaces - on Windows, binding to the
+		// wildcard address does not reliably conflict with an existing
+		// listener bound to a specific address on the same port.
+		Addr: "127.0.0.1:19888",
 	}
 	httpError := make(chan error)
 	go func() {

--- a/internal/storage/FileServing.go
+++ b/internal/storage/FileServing.go
@@ -488,6 +488,8 @@ func generateHashAndEncrypt(fileContent io.Reader, fileHeader *multipart.FileHea
 		helper.Check(err)
 		err = encryption.Encrypt(&encInfo, tempFile, tempFileEnc)
 		helper.Check(err)
+		err = tempFile.Close()
+		helper.Check(err)
 		err = os.Remove(tempFile.Name())
 		helper.Check(err)
 		hash.Write([]byte(configuration.Get().Authentication.SaltFiles))

--- a/internal/storage/FileServing_test.go
+++ b/internal/storage/FileServing_test.go
@@ -9,8 +9,8 @@ import (
 	"net/textproto"
 	"os"
 	"strings"
+	"sync"
 	"testing"
-	"testing/synctest"
 	"time"
 
 	"github.com/forceu/gokapi/internal/configuration"
@@ -18,6 +18,7 @@ import (
 	"github.com/forceu/gokapi/internal/configuration/database"
 	"github.com/forceu/gokapi/internal/encryption"
 	"github.com/forceu/gokapi/internal/helper"
+	"github.com/forceu/gokapi/internal/logging/serverstats"
 	"github.com/forceu/gokapi/internal/models"
 	"github.com/forceu/gokapi/internal/storage/chunking"
 	"github.com/forceu/gokapi/internal/storage/filesystem/s3filesystem/aws"
@@ -30,6 +31,13 @@ func TestMain(m *testing.M) {
 	testconfiguration.Create(true)
 	configuration.Load()
 	configuration.ConnectDatabase()
+	// Initialise the traffic-stats save timer before any test calls ServeFile, so that
+	// no test's background AddTraffic call sees a zero-value LastUpdate (which reads as
+	// "5+ minutes since the last save") and triggers a real, unawaited SQLite write. Left
+	// uninitialised, a write can still be in flight when TestParallelDownloads starts,
+	// where it can collide with the mutex-serialized IncreaseDownloadCount writes and
+	// livelock SQLite's busy-handler retry loop under synctest's deterministic fake clock.
+	serverstats.Init()
 	var testserver *httptest.Server
 	if testconfiguration.UseMockS3Server() {
 		testserver = testconfiguration.StartS3TestServer()
@@ -918,38 +926,45 @@ func TestParallelDownloads(t *testing.T) {
 	}
 	database.SaveMetaData(singleDownloadFile)
 
-	synctest.Test(t, func(t *testing.T) {
-		const workers = 50
-		results := make(chan bool, workers)
+	const workers = 50
+	results := make(chan bool, workers)
+	var wg sync.WaitGroup
 
-		for i := 0; i < workers; i++ {
-			go func() {
-				w := httptest.NewRecorder()
-				r := httptest.NewRequest("GET", "/"+singleDownloadFile.Id, nil)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "/"+singleDownloadFile.Id, nil)
 
-				// The mutex inside ServeFile should serialize the decrement logic.
-				success := ServeFile(singleDownloadFile, w, r, false, true, false, true)
-				results <- success
-			}()
+			// The mutex inside ServeFile should serialize the decrement logic.
+			success := ServeFile(singleDownloadFile, w, r, false, true, false, true)
+			results <- success
+		}()
+	}
+
+	// A plain WaitGroup is used here rather than testing/synctest: this test spawns
+	// real goroutines that hit the real SQLite database, and synctest's deterministic
+	// fake clock has no way to gracefully coexist with unpredictable real-world I/O
+	// delays (e.g. antivirus briefly locking the database file on write) - a single
+	// external stall can turn into an apparent livelock, since retries governed by the
+	// fake clock can spin far faster than the real delay actually resolves.
+	wg.Wait()
+	close(results)
+
+	var successCount int
+	var failureCount int
+
+	for res := range results {
+		if res {
+			successCount++
+		} else {
+			failureCount++
 		}
+	}
 
-		synctest.Wait()
-		close(results)
-
-		var successCount int
-		var failureCount int
-
-		for res := range results {
-			if res {
-				successCount++
-			} else {
-				failureCount++
-			}
-		}
-
-		test.IsEqualInt(t, successCount, allowedDownloads)
-		test.IsEqualInt(t, failureCount, workers-allowedDownloads)
-	})
+	test.IsEqualInt(t, successCount, allowedDownloads)
+	test.IsEqualInt(t, failureCount, workers-allowedDownloads)
 }
 
 func TestServeFilesAsZipSanitisation(t *testing.T) {

--- a/internal/storage/chunking/Chunking_test.go
+++ b/internal/storage/chunking/Chunking_test.go
@@ -8,6 +8,7 @@ import (
 	"net/textproto"
 	"net/url"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -271,10 +272,17 @@ func TestGetFileByChunkId(t *testing.T) {
 	file, err := GetFileByChunkId("testchunk")
 	test.IsEqualString(t, file.Name(), "test/data/chunk-testchunk")
 	test.IsNil(t, err)
-	err = os.Chmod("test/data/chunk-testchunk", 0222)
-	_, err = GetFileByChunkId("testchunk")
-	test.IsNotNil(t, err)
-	err = os.Remove(file.Name())
+	err = file.Close()
+	test.IsNil(t, err)
+	if runtime.GOOS != "windows" {
+		// Windows has no POSIX permission bits, so chmod cannot simulate an
+		// unreadable file there the way it can on Unix-like systems.
+		err = os.Chmod("test/data/chunk-testchunk", 0222)
+		test.IsNil(t, err)
+		_, err = GetFileByChunkId("testchunk")
+		test.IsNotNil(t, err)
+	}
+	err = os.Remove("test/data/chunk-testchunk")
 	test.IsNil(t, err)
 }
 

--- a/internal/storage/filesystem/localstorage/Localstorage_test.go
+++ b/internal/storage/filesystem/localstorage/Localstorage_test.go
@@ -42,13 +42,13 @@ func TestLocalStorageDriver_Init(t *testing.T) {
 		FilePrefix: "tpref",
 	})
 	test.IsEqualBool(t, ok, true)
-	test.IsEqualString(t, driver.getPath(), "test/")
+	test.IsEqualString(t, driver.getPath(), "test"+string(os.PathSeparator))
 	ok = driver.Init(Config{
-		DataPath:   "test2/",
+		DataPath:   "test2" + string(os.PathSeparator),
 		FilePrefix: "",
 	})
 	test.IsEqualBool(t, ok, true)
-	test.IsEqualString(t, driver.getPath(), "test2/")
+	test.IsEqualString(t, driver.getPath(), "test2"+string(os.PathSeparator))
 	defer test.ExpectPanic(t)
 	driver.Init(struct {
 		invalid string
@@ -72,7 +72,7 @@ func TestLocalStorageDriver_IsAvailable(t *testing.T) {
 func TestGetDataPath(t *testing.T) {
 	driver := getTestDriver(t)
 	initDriver(t, driver)
-	test.IsEqualString(t, driver.getPath(), "test/data/")
+	test.IsEqualString(t, driver.getPath(), "test/data"+string(os.PathSeparator))
 	driver.dataPath = ""
 	defer test.ExpectPanic(t)
 	driver.getPath()

--- a/internal/storage/filesystem/s3filesystem/aws/Aws_test.go
+++ b/internal/storage/filesystem/s3filesystem/aws/Aws_test.go
@@ -81,6 +81,7 @@ func TestUploadToAws(t *testing.T) {
 	location, err := Upload(file, testFile)
 	test.IsNil(t, err)
 	test.IsNotEmpty(t, location)
+	file.Close()
 	os.Remove("test")
 }
 
@@ -93,6 +94,7 @@ func TestDownloadFromAws(t *testing.T) {
 	test.FileExists(t, "test")
 	content, _ := os.ReadFile("test")
 	test.IsEqualString(t, string(content), "testfile-content")
+	file.Close()
 	os.Remove("test")
 }
 

--- a/internal/webserver/ssl/Ssl.go
+++ b/internal/webserver/ssl/Ssl.go
@@ -65,6 +65,7 @@ func getDaysRemaining() int {
 	certificate, _ := GetCertificateLocations()
 	file, err := os.Open(certificate)
 	helper.Check(err)
+	defer file.Close()
 	certContent, err := io.ReadAll(file)
 	helper.Check(err)
 	pemContent, _ := pem.Decode(certContent)


### PR DESCRIPTION
## Description
Several tests in the suite fail intermittently (and in some cases deterministically) when run on Windows. Root causes:

- **File handles held open across `os.Remove`**: `generateHashAndEncrypt` (`internal/storage/FileServing.go`) and `getDaysRemaining` (`internal/webserver/ssl/Ssl.go`) didn't close a file handle before removing/rewriting that same file. On Linux this is a no-op; on Windows an open handle blocks the remove/rewrite, so the test either errors out or silently keeps stale data. `Aws_test.go` had the same pattern.
- **`chmod`-based permission tests**: `TestGetFileByChunkId` (`internal/storage/chunking/Chunking_test.go`) used `os.Chmod` to make a file read-only and assert a failing removal - POSIX permission bits are a no-op on Windows, so the assertion never held. Guarded with `runtime.GOOS != "windows"`.
- **Hardcoded `/`-separated path assertions**: `Localstorage_test.go` asserted exact path strings using `/`, which don't match `filepath`-joined paths on Windows (`\`). Switched to `os.PathSeparator`.
- **Wildcard vs. specific address bind conflict**: `TestIsErrorAddressAlreadyInUse` (`Setup_test.go`) bound a test listener to `127.0.0.1:PORT` but the second server to `:PORT` (wildcard). On Windows, binding to the wildcard address doesn't reliably conflict with an existing listener bound to a specific address on the same port, so the intended "address already in use" error never surfaced. Now both bind to the same specific address.
- **`testing/synctest` vs. real I/O contention**: `TestParallelDownloads` used `testing/synctest`'s deterministic fake clock around 50 goroutines doing real SQLite writes. The fake clock has no way to gracefully coexist with unpredictable real-world I/O delays (e.g. antivirus briefly locking the database file) - a single external stall can look like a livelock, since retries governed by the fake clock spin far faster than the real delay actually resolves. Replaced with a plain `sync.WaitGroup`.

None of these are behavior changes to production code paths except the two file-handle fixes, which are strictly more correct (closing a handle before removing/rewriting the same file) on every platform.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Technical Details
- **Database changes:** No
- **Storage backend affected:** No
- **Usage of AI:** Yes — developed with Claude Code as a pair-programming assistant, including root-causing the `synctest` livelock (confirmed via goroutine dumps that the original, unmodified code also hung, ruling out a regression). I reviewed and tested all changes before submitting.

## How Has This Been Tested?
- [x] **Unit Tests:** `go test ./... --tags=test,awsmock` (full suite passes, 15+ repeated runs of the previously-hanging `TestParallelDownloads`)
- [x] **Environment:** Windows 11

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas. (added a comment explaining the `synctest` → `WaitGroup` rationale, since it's non-obvious)
- [x] I have made corresponding changes to the documentation. (n/a - no behavior/doc change)
- [x] My changes generate no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)