### PR TITLE
Fix reversed errors.Is() argument order in CLI uploader

### DIFF
--- a/cmd/cli-uploader/Main.go
+++ b/cmd/cli-uploader/Main.go
@@ -59,7 +59,7 @@ func processUpload(mode int) {
 	result, err := cliapi.UploadFile(uploadParam)
 	if err != nil {
 		fmt.Println()
-		if errors.Is(cliapi.ErrUnauthorised, err) {
+		if errors.Is(err, cliapi.ErrUnauthorised) {
 			fmt.Println("ERROR: Unauthorised API key. Please re-run login or make sure that the API key has the permission to upload files.")
 		} else {
 			fmt.Println("ERROR: Could not upload file")
@@ -88,7 +88,7 @@ func processDownload() {
 	err := cliapi.DownloadFile(uploadParam)
 	if err != nil {
 		fmt.Println()
-		if errors.Is(cliapi.ErrUnauthorised, err) {
+		if errors.Is(err, cliapi.ErrUnauthorised) {
 			fmt.Println("ERROR: Unauthorised API key. Please re-run login or make sure that the API key has the permission to download files.")
 		} else {
 			fmt.Println("ERROR: Could not download file")

--- a/cmd/cli-uploader/cliconfig/cliconfig.go
+++ b/cmd/cli-uploader/cliconfig/cliconfig.go
@@ -50,16 +50,16 @@ func CreateLogin() {
 	vstr, vint, err := cliapi.GetVersion()
 	if err != nil {
 		fmt.Println()
-		if errors.Is(cliapi.ErrUnauthorised, err) {
+		if errors.Is(err, cliapi.ErrUnauthorised) {
 			fmt.Println("ERROR: Unauthorised API key")
 			os.Exit(1)
 		}
-		if errors.Is(cliapi.ErrNotFound, err) {
+		if errors.Is(err, cliapi.ErrNotFound) {
 			fmt.Println("ERROR: API not found")
 			fmt.Println("The provided URL does not respond to API calls as expected. You most likely entered an incorrect URL.")
 			os.Exit(1)
 		}
-		if errors.Is(cliapi.ErrInvalidRequest, err) {
+		if errors.Is(err, cliapi.ErrInvalidRequest) {
 			fmt.Println("ERROR: API does not support Gokapi CLI")
 			fmt.Println("This is most likely caused by an old Gokapi version. Please make sure that your Gokapi instance is running v2.1.0 or newer.")
 			os.Exit(1)
@@ -78,7 +78,7 @@ func CreateLogin() {
 	_, _, isE2E, err := cliapi.GetConfig()
 	if err != nil {
 		fmt.Println("FAIL")
-		if errors.Is(cliapi.ErrUnauthorised, err) {
+		if errors.Is(err, cliapi.ErrUnauthorised) {
 			fmt.Println("ERROR: API key does not have the permission to upload new files.")
 		} else {
 			fmt.Println(err)
@@ -98,7 +98,7 @@ func CreateLogin() {
 		cliapi.Init(url, apikey, e2ekey)
 		_, err = cliapi.GetE2eInfo(true)
 		if err != nil {
-			if errors.Is(cliapi.ErrE2eKeyIncorrect, err) {
+			if errors.Is(err, cliapi.ErrE2eKeyIncorrect) {
 				fmt.Println("ERROR: Incorrect end-to-end encryption key")
 			} else {
 				fmt.Println(err)


### PR DESCRIPTION
## Description
`errors.Is(err, target)` expects the error being checked first and the sentinel second; several calls in the CLI uploader (`cmd/cli-uploader/Main.go`, `cmd/cli-uploader/cliconfig/cliconfig.go`) had them swapped. Harmless today since none of the sentinels are themselves wrapped (so the initial equality check still matches either way), but fixed for correctness and to avoid silently breaking if a sentinel ever gets wrapped.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Technical Details
- **Database changes:** No
- **Storage backend affected:** No
- **Usage of AI:** Yes — developed with Claude Code as a pair-programming assistant (spotted while reviewing the CLI error-handling code, applied the fix). I reviewed and tested all changes before submitting.

## How Has This Been Tested?
- [x] **Unit Tests:** `go test ./... --tags=test,awsmock` (full suite passes; `cmd/cli-uploader` has no test files, this is a straightforward argument-order correction with no behavior change under current conditions)
- [x] **Environment:** Windows 11

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas. (n/a — no new logic, argument-order fix only)
- [x] I have made corresponding changes to the documentation. (n/a — no behavior change)
- [x] My changes generate no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168YUwGEzEHTqd9CwzXE53d
