### PR TITLE
Serve a proper 404 error page for missing static files

### DIFF
--- a/internal/webserver/Webserver.go
+++ b/internal/webserver/Webserver.go
@@ -50,8 +50,6 @@ import (
 	"github.com/forceu/gokapi/internal/webserver/ssl"
 )
 
-// TODO add 404 handler
-
 // staticFolderEmbedded is the embedded version of the "static" folder
 // This contains JS files, CSS, images etc
 //
@@ -175,8 +173,39 @@ func filesystemHandler(webserverDir fs.FS) http.HandlerFunc {
 			return
 		}
 		addCacheHeader(w)
-		http.FileServer(http.FS(webserverDir)).ServeHTTP(w, r)
+		nfw := &notFoundInterceptor{ResponseWriter: w}
+		http.FileServer(http.FS(webserverDir)).ServeHTTP(nfw, r)
+		if nfw.intercepted {
+			// The response was cached as servable content above; a 404 means that
+			// assumption was wrong, so undo it before showing the error page.
+			w.Header().Del("cdn-cache-control")
+			w.Header().Del("Cloudflare-CDN-Cache-Control")
+			w.Header().Del("cache-control")
+			errorHandling.RedirectGenericErrorPage(w, r, errorHandling.TypeFileNotFound)
+		}
 	}
+}
+
+// notFoundInterceptor suppresses http.FileServer's built-in 404 response, so that a
+// styled Gokapi error page can be shown instead of the plain stdlib fallback page.
+type notFoundInterceptor struct {
+	http.ResponseWriter
+	intercepted bool
+}
+
+func (nfw *notFoundInterceptor) WriteHeader(statusCode int) {
+	if statusCode == http.StatusNotFound {
+		nfw.intercepted = true
+		return
+	}
+	nfw.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (nfw *notFoundInterceptor) Write(b []byte) (int, error) {
+	if nfw.intercepted {
+		return len(b), nil
+	}
+	return nfw.ResponseWriter.Write(b)
 }
 
 func handleFavicon(w http.ResponseWriter, r *http.Request) {

--- a/internal/webserver/Webserver_test.go
+++ b/internal/webserver/Webserver_test.go
@@ -74,6 +74,14 @@ func TestStaticDirs(t *testing.T) {
 		RequiredContent: []string{".btn-secondary:hover"},
 	})
 }
+func TestStaticFileNotFound(t *testing.T) {
+	t.Parallel()
+	test.HttpPageResult(t, test.HttpTestConfig{
+		Url:                "http://localhost:53843/this/file/does/not/exist.xyz",
+		RedirectUrl:        "error",
+		IgnoreRedirectParm: true,
+	})
+}
 
 func postValues(username, password, csrf string) []test.PostBody {
 	return []test.PostBody{


### PR DESCRIPTION
## Description
Requests for a static asset that doesn't exist (e.g. a stale/mistyped JS or CSS path) previously fell through `http.FileServer` to the plain stdlib 404 response instead of Gokapi's own styled error page.

Intercepts the `http.FileServer` response via a small `http.ResponseWriter` wrapper: if it would write a 404, the cache headers that were speculatively set for the (assumed-existing) file are removed and the request is redirected to Gokapi's existing generic error page (`errorHandling.RedirectGenericErrorPage` with `TypeFileNotFound`) instead.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Technical Details
- **Database changes:** No
- **Storage backend affected:** No
- **Usage of AI:** Yes — developed with Claude Code as a pair-programming assistant. I reviewed and tested all changes before submitting.

## How Has This Been Tested?
- [x] **Unit Tests:** `go test ./internal/webserver/... --tags=test,awsmock` and full `go test ./... --tags=test,awsmock` suite pass; added `TestStaticFileNotFound` covering the new redirect behavior.
- [x] **Environment:** Windows 11

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation. (n/a — internal error-page behavior, no user-facing docs affected)
- [x] My changes generate no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168YUwGEzEHTqd9CwzXE53d
