### PR TITLE
Handle an aws.ServeFile error gracefully instead of panicking

### DIFF
--- a/internal/storage/FileServing.go
+++ b/internal/storage/FileServing.go
@@ -647,8 +647,10 @@ func ServeFile(file models.File, w http.ResponseWriter, r *http.Request, forceDo
 		// confirm that the file has been completely downloaded. It expires automatically after 24 hours.
 		statusId := downloadstatus.SetDownload(file)
 		isBlocking, err := aws.ServeFile(w, r, file, forceDownload, forceDecryption)
-		// TODO chances are high that an error is returned here, we should consider proper output
-		helper.Check(err)
+		if err != nil {
+			fmt.Println(err)
+			_, _ = w.Write([]byte("Error serving file"))
+		}
 		if isBlocking {
 			downloadstatus.SetComplete(statusId)
 		}

--- a/internal/storage/FileServing_test.go
+++ b/internal/storage/FileServing_test.go
@@ -625,6 +625,37 @@ func TestServeFile(t *testing.T) {
 	test.ResponseBodyContains(t, w, "Error decrypting file")
 }
 
+func TestServeFileAwsErrorHandling(t *testing.T) {
+	if !aws.IsIncludedInBuild {
+		t.Skip("AWS support not included in build")
+	}
+	testconfiguration.EnableS3()
+	config, ok := cloudconfig.Load()
+	test.IsEqualBool(t, ok, true)
+	ok = aws.Init(config.Aws)
+	test.IsEqualBool(t, ok, true)
+
+	// A file with an AWS bucket set, but never actually uploaded, causes aws.ServeFile to
+	// return an error. ServeFile must handle that gracefully instead of panicking.
+	file := models.File{
+		Id:        "awsErrorHandlingTest1",
+		Name:      "aws error handling test",
+		AwsBucket: "gokapi-test",
+		SHA1:      "nonexistentAwsObjectSha1",
+		ExpireAt:  time.Now().Add(time.Hour).Unix(),
+		SizeBytes: 10,
+	}
+	database.SaveMetaData(file)
+
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	ServeFile(file, w, r, false, true, false, false)
+	test.ResponseBodyContains(t, w, "Error serving file")
+
+	database.DeleteMetaData(file.Id)
+	testconfiguration.DisableS3()
+}
+
 func TestCleanUp(t *testing.T) {
 	files := database.GetAllMetadata()
 	downloadstatus.DeleteAll()


### PR DESCRIPTION
## Description
`ServeFile` called `helper.Check(err)` on the result of `aws.ServeFile`, which panics on any error — for example if the object has gone missing from the bucket between the metadata lookup and the actual download, or any other transient S3-side failure. Logs the error and writes a plain error response to the client instead of crashing the request.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Technical Details
- **Database changes:** No
- **Storage backend affected:** S3
- **Usage of AI:** Yes — developed with Claude Code as a pair-programming assistant. I reviewed and tested all changes before submitting.

## How Has This Been Tested?
- [x] **Unit Tests:** Added `TestServeFileAwsErrorHandling`, which registers a file with an AWS bucket set that was never actually uploaded (so the mock driver returns "file not found") and asserts `ServeFile` responds with the error message instead of panicking. Passes in isolation under `go test ./internal/storage/... --tags=test,awsmock -run TestServeFileAwsErrorHandling`.
- [x] **Environment:** Windows 11

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation. (n/a — internal error-handling behavior)
- [x] My changes generate no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168YUwGEzEHTqd9CwzXE53d
