### PR TITLE
Detect unconfigured E2E setup and unauthorized chunk uploads in CLI

### DIFF
--- a/cmd/cli-uploader/cliapi/cliapi.go
+++ b/cmd/cli-uploader/cliapi/cliapi.go
@@ -49,6 +49,9 @@ var ErrFileTooBig = errors.New("file too big")
 // ErrE2eKeyIncorrect is returned when the e2e key is incorrect
 var ErrE2eKeyIncorrect = errors.New("e2e key incorrect")
 
+// ErrE2eNotSetUp is returned when end-to-end encryption has not been set up on the server yet
+var ErrE2eNotSetUp = errors.New("e2e has not been set up on the server")
+
 // Init initialises the API client with the given url and key.
 // The key is used for authentication.
 // The end2endKey is used for end-to-end encryption.
@@ -152,7 +155,6 @@ func UploadFile(uploadParams cliflags.FlagConfig) (models.FileApiOutput, error) 
 	if err != nil {
 		return models.FileApiOutput{}, err
 	}
-	// TODO check for 401
 
 	if len(e2eKey) == 0 || !isE2e || uploadParams.DisableE2e {
 		isE2e = false
@@ -445,6 +447,9 @@ func uploadChunk(f io.Reader, uuid string, offset, chunkSize, filesize int64, pr
 		return err
 	}
 	response := string(bodyContent)
+	if resp.StatusCode == http.StatusUnauthorized {
+		return ErrUnauthorised
+	}
 	if resp.StatusCode != http.StatusOK {
 		return errors.New("failed to upload chunk: status code " + strconv.Itoa(resp.StatusCode) + ", response: " + response)
 	}
@@ -515,6 +520,9 @@ func GetE2eInfo(unlockLock bool) (models.E2EInfoPlainText, error) {
 	err = json.Unmarshal([]byte(resultJson), &result)
 	if err != nil {
 		return models.E2EInfoPlainText{}, err
+	}
+	if !result.HasBeenSetUp() {
+		return models.E2EInfoPlainText{}, ErrE2eNotSetUp
 	}
 	fileInfo, err = end2end.DecryptData(result, e2eKey)
 	if err != nil {

--- a/cmd/cli-uploader/cliconfig/cliconfig.go
+++ b/cmd/cli-uploader/cliconfig/cliconfig.go
@@ -100,12 +100,14 @@ func CreateLogin() {
 		if err != nil {
 			if errors.Is(cliapi.ErrE2eKeyIncorrect, err) {
 				fmt.Println("ERROR: Incorrect end-to-end encryption key")
+			} else if errors.Is(err, cliapi.ErrE2eNotSetUp) {
+				fmt.Println("ERROR: End-to-end encryption has not been set up on the server yet.")
+				fmt.Println("Please complete the E2E setup in the Gokapi web interface first, then try again.")
 			} else {
 				fmt.Println(err)
 			}
 			os.Exit(1)
 		}
-		// TODO check if key has not been generated yet
 	}
 
 	err = save(url, apikey, e2ekey)


### PR DESCRIPTION
## Description
Two small CLI uploader error-detection improvements found while going through its outstanding `// TODO` markers:

- `cliapi.GetE2eInfo` failed decryption with an opaque `ErrE2eKeyIncorrect`-style error whenever a server hadn't had end-to-end encryption set up at all yet — indistinguishable from actually entering the wrong key. It now checks `result.HasBeenSetUp()` first and returns a distinct `ErrE2eNotSetUp`, and `cliconfig.go`'s login flow reports that case with a clear, actionable message instead.
- `uploadChunk` treated a `401 Unauthorized` chunk-upload response the same as any other non-200 status, printing a generic `"status code 401"` message. It now translates that into the existing `ErrUnauthorised` sentinel, matching how the rest of the CLI already reports auth failures.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Technical Details
- **Database changes:** No
- **Storage backend affected:** No
- **Usage of AI:** Yes — developed with Claude Code as a pair-programming assistant. I reviewed and tested all changes before submitting.

## How Has This Been Tested?
- [x] **Manual Testing:** Verified the login flow's error output against a server with no E2E setup, and confirmed a 401 during a chunked upload now reports the same "Unauthorised API key" message as other auth failures.
- [x] **Unit Tests:** `go test ./... --tags=test,awsmock` (full suite passes; `cmd/cli-uploader` has no existing test files to extend)
- [x] **Environment:** Windows 11

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation. (n/a — CLI error-message wording only)
- [x] My changes generate no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0168YUwGEzEHTqd9CwzXE53d
