### PR TITLE
Respect custom Docker mounts in setup warnings

### DIFF
--- a/internal/configuration/setup/Setup.go
+++ b/internal/configuration/setup/Setup.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"runtime"
 	"strconv"
 	"strings"
@@ -717,15 +718,15 @@ type setupView struct {
 
 func (v *setupView) loadFromConfig() {
 	v.IsInitialSetup = isInitialSetup
+	env := environment.New()
 	if environment.IsDockerInstance() {
 		v.IsDocker = true
-		v.IsDataNotMounted = !isVolumeMounted("/app/data")
-		v.IsConfigNotMounted = !isVolumeMounted("/app/config")
+		v.IsDataNotMounted = !isVolumeMounted(env.DataDir)
+		v.IsConfigNotMounted = !isVolumeMounted(env.ConfigDir)
 	}
 	v.HasAwsFeature = aws.IsIncludedInBuild
 	v.ProtectedUrls = protectedUrls
 	if isInitialSetup {
-		env := environment.New()
 		v.MinPasswordLength = env.MinLengthPassword
 		v.CloudSettings, _ = cloudconfig.Load()
 		v.S3EnvProvided = env.IsAwsProvided()
@@ -748,7 +749,6 @@ func (v *setupView) loadFromConfig() {
 	} else {
 		v.Port = environment.DefaultPort
 	}
-	env := environment.New()
 	v.S3EnvProvided = env.IsAwsProvided()
 	v.MinPasswordLength = env.MinLengthPassword
 
@@ -757,19 +757,29 @@ func (v *setupView) loadFromConfig() {
 	v.DatabaseSettings = dbSettings
 }
 
-func isVolumeMounted(path string) bool {
+func isVolumeMounted(dir string) bool {
 	file, err := os.Open("/proc/mounts")
 	if err != nil {
 		fmt.Println(err)
 		return false
 	}
 	defer file.Close()
+	return isPathMounted(file, dir)
+}
 
-	scanner := bufio.NewScanner(file)
+func isPathMounted(mounts io.Reader, dir string) bool {
+	if !path.IsAbs(dir) {
+		dir = path.Join("/app", dir)
+	}
+	dir = path.Clean(dir)
+	scanner := bufio.NewScanner(mounts)
 	for scanner.Scan() {
-		line := scanner.Text()
-		fields := strings.Fields(line)
-		if len(fields) > 1 && fields[1] == path {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 2 {
+			continue
+		}
+		mountPath := path.Clean(fields[1])
+		if mountPath != "/" && (dir == mountPath || strings.HasPrefix(dir, mountPath+"/")) {
 			return true
 		}
 	}

--- a/internal/configuration/setup/Setup_test.go
+++ b/internal/configuration/setup/Setup_test.go
@@ -175,6 +175,17 @@ func TestAddTrailingSlash(t *testing.T) {
 	test.IsEqualString(t, addTrailingSlash("test2/"), "test2/")
 }
 
+func TestIsPathMounted(t *testing.T) {
+	mounts := strings.NewReader("overlay / overlay rw 0 0\n/dev/vda /mnt_vol ext4 rw 0 0\n")
+	test.IsEqualBool(t, isPathMounted(mounts, "/mnt_vol/data"), true)
+
+	mounts = strings.NewReader("overlay / overlay rw 0 0\n/dev/vdb /app/data ext4 rw 0 0\n")
+	test.IsEqualBool(t, isPathMounted(mounts, "data"), true)
+
+	mounts = strings.NewReader("overlay / overlay rw 0 0\n")
+	test.IsEqualBool(t, isPathMounted(mounts, "/mnt_vol/data"), false)
+}
+
 func TestError(t *testing.T) {
 	w := httptest.NewRecorder()
 	outputError(w, errors.New("test error"))


### PR DESCRIPTION
## Description

### Context

The setup page checks only `/app/data` and `/app/config` when deciding whether Docker storage is persistent. Custom `GOKAPI_DATA_DIR` and `GOKAPI_CONFIG_DIR` values therefore trigger data-loss warnings even when those directories live under a mounted parent volume.

Fixes #387

### Changes

- Check the resolved data and config directories from the existing environment parser.
- Treat a non-root parent mount as persistent while excluding the container root filesystem.
- Preserve the default relative `data` and `config` paths by resolving them under `/app`.
- Add regression coverage for custom parent mounts, relative defaults, and root-only mounts.

### User impact

Docker deployments that place both directories below one custom volume no longer receive false data-loss warnings. Unmounted directories continue to warn.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Technical Details

- **Database changes:** No
- **Storage backend affected:** No
- **Usage of AI:** Yes — AI-assisted implementation and test drafting; the complete diff and verification output were reviewed before submission.

## How Has This Been Tested?

- `go test --tags=test,noaws ./internal/configuration/setup -run TestIsPathMounted -count=1` — passed.
- `go vet --tags=test,noaws ./internal/configuration/setup` — passed.
- `go build --tags=noaws ./...` — passed.
- `go generate ./...` — passed with no generated diff.
- Both repository test matrices (`test,noaws` and `test,awsmock`) were attempted sequentially. The changed regression passes; the broader Windows run retains existing path-separator, open-file cleanup, setup-port timeout, and certificate-date failures. Representative path and setup-timeout failures reproduce on clean `origin/master`.
- **Environment:** Windows 11, Go 1.26.7; Linux `/proc/mounts` input covered through a deterministic parser test.

## Checklist

- [x] I have performed a self-review of my own code.
- Comments were not added because the mount-boundary logic is direct and covered by tests.
- Documentation changes are not required because configured paths and setup procedures are unchanged.
- [x] My changes generate no new warnings.